### PR TITLE
fix: typo in relativenumber setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
   },
   window_options = {
     number = true,
-    relativenumbers = true,
+    relativenumber = true,
   },
   view_config = {
     git_status = {

--- a/lua/fyler/lib/config.lua
+++ b/lua/fyler/lib/config.lua
@@ -15,7 +15,7 @@
 
 ---@class Fyler.Config.WindowOptions
 ---@field number boolean
----@field relativenumbers boolean
+---@field relativenumber boolean
 
 ---@class Fyler.Config.ViewConfig
 ---@field git_status { enable: boolean }
@@ -30,7 +30,7 @@ local defaults = {
   },
   window_options = {
     number = true,
-    relativenumbers = true,
+    relativenumber = true,
   },
   view_config = {
     git_status = {


### PR DESCRIPTION
As specified in the [docs](https://neovim.io/doc/user/options.html#'relativenumber'), the `relativenumber` option does not end with an S. Took me a bit to realize why it wasn't working when I copied the default config from the README. Hopefully I'll be the last to have this issue :smile: 