### PR TITLE
feat: Add fyler prefix to fyler windows

### DIFF
--- a/lua/fyler/autocmds.lua
+++ b/lua/fyler/autocmds.lua
@@ -12,7 +12,7 @@ function M.setup()
   })
 
   api.nvim_create_autocmd("BufWriteCmd", {
-    pattern = "file_tree",
+    pattern = "fyler://*",
     group = require("fyler").augroup,
     callback = function(arg)
       api.nvim_exec_autocmds("User", { pattern = "Synchronize" })
@@ -22,7 +22,7 @@ function M.setup()
   })
 
   api.nvim_create_autocmd("BufReadCmd", {
-    pattern = "file_tree",
+    pattern = "fyler://*",
     group = require("fyler").augroup,
     callback = function(arg)
       api.nvim_exec_autocmds("User", { pattern = "RefreshView" })

--- a/lua/fyler/lib/win.lua
+++ b/lua/fyler/lib/win.lua
@@ -14,6 +14,7 @@ local api = vim.api
 ---@field ui            FylerUi
 ---@field open          boolean
 ---@field name          string
+---@field bufname       string
 ---@field kind          FylerWinKind
 ---@field enter         boolean
 ---@field bufnr?        integer
@@ -42,6 +43,7 @@ end
 
 ---@class FylerWinOpts
 ---@field name           string
+---@field bufname        string
 ---@field kind           FylerWinKind
 ---@field enter          boolean
 ---@field render?        fun(): FylerUiLine[]
@@ -57,6 +59,7 @@ function Win.new(opts)
   opts = opts or {}
 
   assert(opts.name, "name is required field")
+  assert(opts.bufname, "bufname is required field")
   assert(opts.kind, "kind is required field")
   assert(opts.mappings, "mappings is required field")
 
@@ -64,6 +67,7 @@ function Win.new(opts)
   local instance = {
     open           = false,
     name           = opts.name,
+    bufname        = opts.bufname,
     kind           = opts.kind,
     enter          = opts.enter,
     render         = opts.render,
@@ -141,7 +145,7 @@ function Win:show()
     self.ui:render(self.render())
   end
 
-  api.nvim_buf_set_name(self.bufnr, self.name)
+  api.nvim_buf_set_name(self.bufnr, self.bufname)
 
   -- Setup keyamps
   for mode, map in pairs(self.mappings) do

--- a/lua/fyler/views/file_tree/init.lua
+++ b/lua/fyler/views/file_tree/init.lua
@@ -48,7 +48,7 @@ function FileTreeView:open(opts)
   self.win = Win.new {
     enter = true,
     name = "file_tree",
-    -- bufname = string.format("fyler://%s", self.cwd),
+    bufname = string.format("fyler://%s", self.cwd),
     kind = opts.kind,
     bufopts = {
       syntax = "fyler",


### PR DESCRIPTION
Hello!

Currently, Fyler's windows are created using a simple "file_tree" name, as evidenced [here](https://github.com/A7Lavinraj/fyler.nvim/blob/4d8ae016736fd551bb3af25cdfd25a5abc0367ea/lua/fyler/views/file_tree/init.lua#L50). This means, however, that Fyler's buffer name will then be somethine like `$CWD/file_tree` (e.g. if CWD is `/foo/bar/baz`, the buffer will be named `/foo/bar/baz/file_tree`). This makes it difficult to create scripting tools that have to locate Fyler's buffer.

I'm currently suggesting using the `fyler://` prefix before the name to prevent the default $CWD expansion that neovim does.