### PR TITLE
feat: Add action for recursive toggle on directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@
         n = {
           ["q"] = "CloseView",
           ["<CR>"] = "Select",
+          ["<C-CR>"] = "SelectRecursive",
         },
       },
     },

--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -29,6 +29,7 @@ local defaults = {
       n = {
         ["q"] = "CloseView",
         ["<CR>"] = "Select",
+        ["<C-CR>"] = "SelectRecursive",
       },
     },
   },

--- a/lua/fyler/views/file_tree/actions.lua
+++ b/lua/fyler/views/file_tree/actions.lua
@@ -43,6 +43,23 @@ function M.n_select(view)
   end
 end
 
+function M.n_select_recursive(view)
+  return function()
+    local key = regex.getkey(api.nvim_get_current_line())
+    if not key then
+      return
+    end
+
+    local meta_data = store.get(key)
+    if meta_data.type == "directory" then
+      view.tree_node:find(key):toggle_recursive()
+      view:refresh()
+    else
+      M.n_select(view)
+    end
+  end
+end
+
 ---@param tbl table
 ---@return table
 local function get_tbl(tbl)

--- a/lua/fyler/views/file_tree/init.lua
+++ b/lua/fyler/views/file_tree/init.lua
@@ -88,8 +88,9 @@ function FileTreeView:open(opts)
     -- stylua: ignore start
     mappings = {
       n = {
-        [mappings["Select"]]     = self:_action("n_select"),
-        [mappings["CloseView"]]  = self:_action("n_close_view"),
+        [mappings["Select"]]          = self:_action("n_select"),
+        [mappings["SelectRecursive"]] = self:_action("n_select_recursive"),
+        [mappings["CloseView"]]       = self:_action("n_close_view"),
       },
     },
     autocmds = {

--- a/lua/fyler/views/file_tree/struct.lua
+++ b/lua/fyler/views/file_tree/struct.lua
@@ -83,4 +83,31 @@ function TreeNode:update()
   end
 end
 
+function TreeNode:open_recursive()
+  self.open = true
+  self:update()
+  for _, child in pairs(self.children) do
+    if store.get(child.data).type == "directory" then
+      child:open_recursive()
+    end
+  end
+end
+
+function TreeNode:close_recursive()
+  for _, child in pairs(self.children) do
+    if store.get(child.data).type == "directory" and child.open then
+      child:close_recursive()
+    end
+  end
+  self.open = false
+end
+
+function TreeNode:toggle_recursive()
+  if self.open then
+    self:close_recursive()
+  else
+    self:open_recursive()
+  end
+end
+
 return M


### PR DESCRIPTION
A new action is introduced: "SelectRecursive", which allows the user to open/close all directories in a directory tree. As an example:

```
dir
foo  <--- Cursor here. foo is a directory
dir
file
file
```
After hitting `<C-CR>`:
```
dir
foo   <--- Cursor still here. All subdirs are open
   dir
      file
   dir
      file
      file
   dir
      file
   file
   file
dir
file
file
```

The action's default mapping is `<C-CR>`.

Let me know if this is an undesired feature, or if any cleanup is necessary

