### PR TITLE
fix: incorrect find method for file name

### DIFF
--- a/lua/fyler/views/file_tree/actions.lua
+++ b/lua/fyler/views/file_tree/actions.lua
@@ -147,7 +147,7 @@ function M.constrain_cursor(view)
       end
 
       local row, col = unpack(api.nvim_win_get_cursor(view.win.winid))
-      local lb, ub = cline:find(item_name)
+      local lb, ub = cline:find(item_name, 1, true)
       lb = lb - 1
       ub = ub - 1
 


### PR DESCRIPTION
`string.find` method's third parameter is a boolean that controls whether to disable regex in your match. It defaults to false. That means, if the file has a name with any of regex's special character, this method would fail to find it.

An example would be a file name with a dash: `foo-bar`. It would cause Fyler to crash

Simply setting the third parameter to true fixes this issue.