### PR TITLE
fix: Use correct path in file creation on windows

### DIFF
--- a/lua/fyler/lib/fs.lua
+++ b/lua/fyler/lib/fs.lua
@@ -202,8 +202,12 @@ M.mkdir_p = a.async(function(path, cb)
     end)
     :totable()
 
-  local dir = ""
-  for i = 1, #parts do
+  local is_win = vim.fn.has("win32")
+
+  local dir = is_win and parts[1] or ""
+
+  local start_idx = is_win and 2 or 1
+  for i = start_idx, #parts do
     dir = dir .. string.format("/%s", parts[i])
 
     local _, stat = a.await(uv.fs_stat, dir)


### PR DESCRIPTION
Creating files and directories did not work on Windows because the first part of the path contained the drive letter.

This adds some Windows-specific logic that should handle the drive letter correctly.