### PR TITLE
fix: Remove confirmation when no operation has to be performed

### DIFF
--- a/lua/fyler/views/explorer/actions.lua
+++ b/lua/fyler/views/explorer/actions.lua
@@ -111,6 +111,10 @@ function M.n_synchronize(view)
   return a.async(function()
     local changes = algos.get_diff(view)
     local can_sync = (function()
+      if #changes.create == 0 and #changes.delete == 0 and #changes.move == 0 then
+        return true
+      end
+
       if not config.values.auto_confirm_simple_edits then
         return a.await(confirm_view.open, get_tbl(changes), "(y/n)")
       end


### PR DESCRIPTION
resolves: #44