### PR TITLE
feat: allow to specify absolute window size

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ local defaults = {
 
   -- Views configuration:
   -- Every view config contains following options to be customized
-  -- `width` a number in (0, 1]
-  -- `height` a number in (0, 1]
+  -- `width` a number in (0, 1] for relative size or [1, ...] for absolute size
+  -- `height` a number in (0, 1] for relative size or [1, ...] for absolute size
 
   -- `kind` could be as following:
   -- 'float',

--- a/lua/fyler/lib/win.lua
+++ b/lua/fyler/lib/win.lua
@@ -134,8 +134,8 @@ function Win:config()
     winconfig.row = math.floor((1 - self.height) * 0.5 * vim.o.lines)
   end
 
-  winconfig.width = math.ceil(self.width * vim.o.columns)
-  winconfig.height = math.ceil(self.height * vim.o.lines)
+  winconfig.width = (self.width <= 1.0) and math.ceil(self.width * vim.o.columns) or self.width
+  winconfig.height = (self.height <= 1.0) and math.ceil(self.height * vim.o.lines) or self.height
 
   return winconfig
 end


### PR DESCRIPTION
- [x] I have read and follow [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)

In some situations user may wish to specify absolute size for width and/or height of fyler window. This PR allows user to do so.