### PR TITLE
feat!: Add support for vim.opt.winborder

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,15 @@ local defaults = {
   -- 'split:rightmost',
   -- 'split:belowmost'
 
-  -- for `border` |:help winborder|
+  -- For `border` see |:help winborder|
+  -- When set to `nil`, it uses `vim.o.winborder` value on nvim 0.11+,
+  -- otherwise, it defaults to 'single'
   views = {
     confirm = {
       width = 0.8,
       height = 0.8,
       kind = "float",
-      border = "single",
+      border = nil,
       buf_opts = {
         buflisted = false,
         modifiable = false,
@@ -146,7 +148,7 @@ local defaults = {
       width = 0.8,
       height = 0.8,
       kind = "float",
-      border = "single",
+      border = nil,
       buf_opts = {
         buflisted = false,
         buftype = "acwrite",

--- a/doc/fyler.txt
+++ b/doc/fyler.txt
@@ -30,7 +30,7 @@ Fyler supports plenty of options to customize. Following are default values
         width = 0.8,
         height = 0.8,
         kind = "float",
-        border = "single",
+        border = nil,
         buf_opts = {
           buflisted = false,
           modifiable = false,
@@ -44,7 +44,7 @@ Fyler supports plenty of options to customize. Following are default values
         width = 0.8,
         height = 0.8,
         kind = "float",
-        border = "single",
+        border = nil,
         buf_opts = {
           buflisted = false,
           buftype = "acwrite",

--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -2,7 +2,7 @@
 ---@field width  number
 ---@field height number
 ---@field kind   FylerWinKind
----@field border string|string[]
+---@field border nil|string|string[]
 
 ---@class FylerConfig
 ---@field auto_confirm_simple_edits? boolean
@@ -48,7 +48,7 @@ local defaults = {
       width = 0.5,
       height = 0.4,
       kind = "float",
-      border = "single",
+      border = nil,
       buf_opts = {
         buflisted = false,
         modifiable = false,
@@ -62,7 +62,7 @@ local defaults = {
       width = 0.8,
       height = 0.8,
       kind = "float",
-      border = "single",
+      border = nil,
       buf_opts = {
         buflisted = false,
         buftype = "acwrite",

--- a/lua/fyler/lib/win.lua
+++ b/lua/fyler/lib/win.lua
@@ -16,7 +16,7 @@ local api = vim.api
 ---@class FylerWin
 ---@field augroup       string          - Autogroup associated with window instance
 ---@field autocmds      table           - Autocommands locally associated with window instance
----@field border        string|string[] - Border format - read ':winborder' for more info
+---@field border        nil|string|string[]   - Border format, see ':help winborder' for more info. When set to `nil`, it uses `vim.o.winborder` value on nvim 0.11+, otherwise, it defaults to 'single'
 ---@field bufname       string          - Builtin way to name neovim buffers
 ---@field bufnr?        integer         - Buffer number associated with window instance
 ---@field buf_opts      table           - Buffer local options
@@ -25,7 +25,7 @@ local api = vim.api
 ---@field footer_pos?   string          - Footer alignment
 ---@field height        number          - Height of window
 ---@field kind          FylerWinKind    - Decides launch behaviour of window instance
----@field mappings      table           - Kemaps local to the window instance
+---@field mappings      table           - Keymaps local to the window instance
 ---@field name          string          - Also know as `view_name` which helps to get specific config from user end
 ---@field namespace     integer         - Namespace associated with window instance
 ---@field render?       function        - Defines what to render on the screen on open
@@ -59,11 +59,21 @@ local M = setmetatable({}, {
     assert(opts.name, "name is required field")
     assert(opts.bufname, "bufname is required field")
 
+    -- support neovim 0.11+ vim.o.winborder option
+    local border = opts.border
+    if vim.o.winborder ~= nil and opts.border == nil then
+      if vim.o.winborder ~= '' then
+        border = vim.o.winborder
+      else
+        border = 'single'
+      end
+    end
+
     -- stylua: ignore start
     local instance = {
       augroup       = get_augroup(opts.name),
       autocmds      = opts.autocmds or {},
-      border        = opts.border,
+      border        = border,
       bufname       = opts.bufname,
       buf_opts      = opts.buf_opts or {},
       enter         = opts.enter,

--- a/lua/fyler/lib/win.lua
+++ b/lua/fyler/lib/win.lua
@@ -16,7 +16,9 @@ local api = vim.api
 ---@class FylerWin
 ---@field augroup       string          - Autogroup associated with window instance
 ---@field autocmds      table           - Autocommands locally associated with window instance
----@field border        nil|string|string[]   - Border format, see ':help winborder' for more info. When set to `nil`, it uses `vim.o.winborder` value on nvim 0.11+, otherwise, it defaults to 'single'
+---@field border        nil|string|string[] - Border format, see ':help winborder' for more info.
+---                                         When set to `nil`, it uses `vim.o.winborder` value on nvim 0.11+,
+---                                         otherwise, it defaults to 'single'
 ---@field bufname       string          - Builtin way to name neovim buffers
 ---@field bufnr?        integer         - Buffer number associated with window instance
 ---@field buf_opts      table           - Buffer local options
@@ -62,10 +64,10 @@ local M = setmetatable({}, {
     -- support neovim 0.11+ vim.o.winborder option
     local border = opts.border
     if vim.o.winborder ~= nil and opts.border == nil then
-      if vim.o.winborder ~= '' then
+      if vim.o.winborder ~= "" then
         border = vim.o.winborder
       else
-        border = 'single'
+        border = "single"
       end
     end
 


### PR DESCRIPTION
- [x] I have read and follow [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)

Added support for `vim.opt.winborder`, which is introduced in nvim 0.11 [#31074](https://github.com/neovim/neovim/pull/31074).

### Changes:

- Added handling of `winborder` in `setmetatable` at `lua/fyler/lib/win.lua`
- Changed the default border option to `nil` to respect `vim.opt.winborder` on Neovim 0.11+
- Updated documentation and type definition for border