### PR TITLE
fix(explorer): ensure space indentation and width are the same to avoid tab indentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ local defaults = {
       border = nil,
       buf_opts = {
         expandtab = true,
+        shfitwidth = 2,
         buflisted = false,
         buftype = "acwrite",
         filetype = "fyler",

--- a/doc/fyler.txt
+++ b/doc/fyler.txt
@@ -47,6 +47,7 @@ Fyler supports plenty of options to customize. Following are default values
         border = nil,
         buf_opts = {
           expandtab = true,
+          shfitwidth = 2,
           buflisted = false,
           buftype = "acwrite",
           filetype = "fyler",

--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -65,6 +65,7 @@ local defaults = {
       border = nil,
       buf_opts = {
         expandtab = true,
+        shfitwidth = 2,
         buflisted = false,
         buftype = "acwrite",
         filetype = "fyler",


### PR DESCRIPTION
- [x] I have read and follow [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)

I often use tabs as my indentation and when trying to create a new file, it breaks the indentation level, thus moving all files from a directory, to somewhere else. IMO i think this should be set as an default value, this also resolves my issue.