### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ fyler.open()
 fyler.open({ cwd = "~/" })
 
 -- Open with specific kind
-fyler.open({ cwd = "split_left_most" })
+fyler.open({ kind = "split_left_most" })
 ```
 
 ## TODOS


### PR DESCRIPTION
`split_left_most` is a 'kind' configuration, not directory which `cwd` would refer to.

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
