### PR TITLE
[FIX] Invalid path hijacking

### DIFF
--- a/lua/fyler/autocmds.lua
+++ b/lua/fyler/autocmds.lua
@@ -51,9 +51,6 @@ function M.setup(config)
   api.nvim_create_autocmd("BufEnter", {
     group = augroup,
     callback = function(arg)
-      -- Don't interfere with terminal buffers
-      if vim.bo[arg.buf].buftype == "terminal" or vim.bo[arg.buf].filetype == "toggleterm" then return end
-
       local cur_instance = require("fyler.views.explorer").get_current_instance()
       if cur_instance then cur_instance:_action("try_focus_buffer")(arg) end
     end,

--- a/lua/fyler/lib/fs.lua
+++ b/lua/fyler/lib/fs.lua
@@ -31,6 +31,13 @@ function M.abspath(path) return vim.fs.abspath(path) end
 function M.relpath(base, path) return vim.fs.relpath(base, path) end
 
 ---@param path string
+---@return boolean
+function M.is_valid_path(path)
+  local _, err = uv.fs_stat(path)
+  return err == nil
+end
+
+---@param path string
 ---@return string|nil, string|nil
 function M.resolve_link(path)
   local res_path = nil

--- a/lua/fyler/views/explorer/actions.lua
+++ b/lua/fyler/views/explorer/actions.lua
@@ -334,7 +334,7 @@ end
 ---@param view FylerExplorerView
 function M.try_focus_buffer(view)
   return schedule_async(function(arg)
-    if arg.file == "" then return end
+    if not fs.is_valid_path(arg.file) then return end
 
     if not view.win:has_valid_winid() then return end
 


### PR DESCRIPTION
I have been using Fyler predominantly with `split_left_most` and having it sit there during my entire session. I have noticed poor window management behavior when also using ToggleTerm in a floating style. Fyler tries to hijack my floating terminal window (presumably to update its explorer tree view).

Anyways, tap into the autocmds to disable hijacking for terminals or specifically ToggleTerm.

Fixes: https://github.com/A7Lavinraj/fyler.nvim/issues/113