### PR TITLE
[FIX] `is_valid_path` prefix error

### DIFF
--- a/lua/fyler/lib/fs.lua
+++ b/lua/fyler/lib/fs.lua
@@ -33,7 +33,8 @@ function M.relpath(base, path) return vim.fs.relpath(base, path) end
 ---@param path string
 ---@return boolean
 function M.is_valid_path(path)
-  local _, err = uv.fs_stat(path)
+  local prefixless_path = string.gsub(path, "^fyler://", "")
+  local _, err = uv.fs_stat(prefixless_path)
   return err == nil
 end
 


### PR DESCRIPTION
The `is_valid_path` function was always returning false as the `"fyler://"` prefix was being included in the path passed to `uv.fs_stat`. As a result, the current buffer was not being revealed on opening Fyler.

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
