### PR TITLE
feat: add customizable command support (naive) for explorer view

### DIFF
--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -113,6 +113,10 @@ local defaults = {
       ["n"] = "Discard",
     },
   },
+  commands = {
+    explorer = {},
+    confirm = {},
+  },
 
   -- "views" is a map to corresponding configuration
   views = {
@@ -273,6 +277,13 @@ end
 function M.get_mappings(name)
   assert(name, "name is required")
   return M.values.mappings[name]
+end
+
+-- Returns customized commands for a particular "view"
+---@param name string
+function M.get_commands(name)
+  assert(name, "name is required")
+  return M.values.commands[name]
 end
 
 -- Type check for configuration option


### PR DESCRIPTION
- New `commands` table in config defaults with `explorer` and `confirm` sections
- `get_commands()` function to retrieve view-specific commands
- Enhanced mapping logic that checks for user-defined commands before falling back to native actions
- Proper error handling for unavailable native actions

- [ ] I have read and follow [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)

now new config supports commands like
```lua
{
      mappings = {
        explorer = {
          ["h"] = "MyCommand",
        },
      },
      commands = {
        explorer = {
          ---@param view FylerExplorerView
          ---@return fun()
          ["MyCommand"] = function(view)
            local algos = require("fyler.views.explorer.algos")
            local store = require("fyler.views.explorer.store")
            local api = vim.api
            return function()
              local itemid = algos.match_itemid(api.nvim_get_current_line())
              if not itemid then
                return
              end
              local entry = store.get_entry(itemid)
              vim.notify(vim.inspect(entry))
            end
          end,
        },
}

```