### PR TITLE
Feature/commands

### DIFF
--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -113,11 +113,6 @@ local defaults = {
       ["n"] = "Discard",
     },
   },
-  commands = {
-    explorer = {},
-    confirm = {},
-  },
-
   -- "views" is a map to corresponding configuration
   views = {
     confirm = {
@@ -277,13 +272,6 @@ end
 function M.get_mappings(name)
   assert(name, "name is required")
   return M.values.mappings[name]
-end
-
--- Returns customized commands for a particular "view"
----@param name string
-function M.get_commands(name)
-  assert(name, "name is required")
-  return M.values.commands[name]
 end
 
 -- Type check for configuration option

--- a/lua/fyler/views/explorer/init.lua
+++ b/lua/fyler/views/explorer/init.lua
@@ -19,17 +19,19 @@ function ExplorerView:open(opts)
   local view_config = config.get_view_config("explorer", opts.kind)
   local mappings = {}
 
-  local user_actions = config.get_commands("explorer")
-  local user_action_names = vim.tbl_keys(user_actions)
-
-  util.tbl_each(config.get_mappings("explorer"), function(key, action_name)
-    if vim.tbl_contains(user_action_names, action_name) then
-      mappings[key] = user_actions[action_name](self)
+  util.tbl_each(config.get_mappings("explorer"), function(key, action)
+    if type(action) == "function" then
+      -- if action is a function, wrap it to pass self as the first argument
+      mappings[key] = function() action(self) end
       return
+    elseif type(action) == "string" then
+      local success, native_action = pcall(self._action, self, util.camel_to_snake(string.format("n%s", action)))
+      if not success or native_action == nil then
+        vim.notify("" .. string.format("Mapping action %s is not available", action), vim.log.levels.WARN)
+        return
+      end
+      mappings[key] = native_action
     end
-    local native_action = self:_action(util.camel_to_snake(string.format("n%s", action_name)))
-    if native_action == nil then error(string.format("Mapping action %s is not available", action_name)) end
-    mappings[key] = native_action
   end)
 
   -- stylua: ignore start


### PR DESCRIPTION
- [x] I have read and follow [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)

add a naive implementation of user defined mappings in both explorer view and confirm view.
Now the mappings support direct function support.
Also add error handle to avoid crush when an action is not avaliable.

```lua
      mappings = {
        explorer = {
          ---@param view FylerExplorerView
          ["Y"] = function(view)
            local algos = require("fyler.views.explorer.algos")
            local store = require("fyler.views.explorer.store")
            local api = vim.api
            local itemid = algos.match_itemid(api.nvim_get_current_line())
            if not itemid then
              return
            end
            local entry = store.get_entry(itemid)
            vim.notify(vim.inspect(entry))
            -- require("utils.yank_path").yank_path_picker(entry.path)
          end,
        },
        confirm = {
          ---@param view FylerConfirmView
          ---@param cb fun(confirmed: boolean)
          ["N"] = function(view, cb)
            cb(false)
            vim.notify("Cancelled", vim.log.levels.INFO)
            view:close()
          end,
        },
      },


```