### PR TITLE
feat(actions): toggle preview

### DIFF
--- a/doc/fyler.txt
+++ b/doc/fyler.txt
@@ -31,6 +31,7 @@ Fyler supports plenty of options to customize. Following are default values
         ["^"] = "GotoParent",
         ["="] = "GotoCwd",
         ["."] = "GotoNode",
+        ["P"] = "TogglePreview",
       },
       confirm = {
         ["y"] = "Confirm",

--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -25,6 +25,7 @@ local util = require("fyler.lib.util")
 ---| "GotoParent" Jump to parent directory
 ---| "GotoCwd" Jump to current working directory
 ---| "GotoNode" Jump to node under cursor
+---| "TogglePreview" Preview file under cursor without switching focus
 
 ---@alias FylerConfigMappingsConfirm
 ---| "Confirm" Confirm actions
@@ -91,6 +92,7 @@ local defaults = {
       ["^"] = "GotoParent",
       ["="] = "GotoCwd",
       ["."] = "GotoNode",
+      ["P"] = "TogglePreview",
     },
     confirm = {
       ["y"] = "Confirm",


### PR DESCRIPTION
- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)


closes: https://github.com/A7Lavinraj/fyler.nvim/issues/70

TODO:
- [x] toggle preview mode with `P`
- [X] reset the toggle state when stopped
- [x] do not update jumplist
- [ ] fix moving the cursor quickly is laggy _(if you have any tips let me know!)_
- [ ] fix starting preview mode on a directory
- [ ] fix create/update/delete files when preview mode is enabled
- [ ] fix cursor goes to the beginning of the line with enabled and moving up and down with `j` / `k`
- [ ] fix do not override `k` and `j` _(if you have any tips let me know!)_
- [ ] stop preview mode when `wq` or `<CR>` _(if you have any tips let me know!)_