### PR TITLE
[FIX] Escape filename for special characters

### DIFF
--- a/lua/fyler/explorer/actions.lua
+++ b/lua/fyler/explorer/actions.lua
@@ -36,7 +36,7 @@ function M.n_select(self)
         if self.config.values.close_on_select then self.win:hide() end
 
         api.nvim_set_current_win(self.win.old_winid)
-        api.nvim_win_call(self.win.old_winid, function() vim.cmd.edit(entry.path) end)
+        api.nvim_win_call(self.win.old_winid, function() vim.cmd.edit(vim.fn.fnameescape(entry.path)) end)
       end
     end
   end


### PR DESCRIPTION
resolves: #143

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)
