### PR TITLE
Add ability to collapse node under cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ local defaults = {
     ["="] = "GotoCwd",
     ["."] = "GotoNode",
     ["#"] = "CollapseAll",
+    ["<BS>"] = "CollapseNode",
   },
   -- Auto current buffer tracking
   track_current_buffer = true,

--- a/doc/fyler.txt
+++ b/doc/fyler.txt
@@ -56,6 +56,7 @@ Fyler supports plenty of options to customize. Following are default values
       ["="] = "GotoCwd",
       ["."] = "GotoNode",
       ["#"] = "CollapseAll",
+      ["<BS>"] = "CollapseNode",
     },
     track_current_buffer = true,
     win = {

--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -136,6 +136,7 @@ local function defaults()
       ["="] = "GotoCwd",
       ["."] = "GotoNode",
       ["#"] = "CollapseAll",
+      ["<BS>"] = "CollapseNode",
     },
     track_current_buffer = true,
     win = {

--- a/lua/fyler/explorer.lua
+++ b/lua/fyler/explorer.lua
@@ -111,6 +111,7 @@ function M:open(dir, kind)
     mappings      = {
       [reversed_maps["CloseView"]]    = self:_action "n_close",
       [reversed_maps["CollapseAll"]]  = self:_action "n_collapse_all",
+      [reversed_maps["CollapseNode"]] = self:_action "n_collapse_node",
       [reversed_maps["GotoCwd"]]      = self:_action "n_goto_cwd",
       [reversed_maps["GotoNode"]]     = self:_action "n_goto_node",
       [reversed_maps["GotoParent"]]   = self:_action "n_goto_parent",

--- a/lua/fyler/explorer/file_tree.lua
+++ b/lua/fyler/explorer/file_tree.lua
@@ -136,6 +136,17 @@ function M:collapse_node(node_value)
   EntryByref_id[node.value].open = false
 end
 
+---@param node_value integer
+function M:find_parent(node_value)
+  assert(node_value, "cannot find node without node_value")
+
+  local node = self.tree:find(node_value)
+  assert(node, "cannot locate node with given node_value")
+
+  if not node.parent then return nil end
+  return node.parent.value
+end
+
 function M:collapse_all()
   if not self.tree.root then return end
 


### PR DESCRIPTION
- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)

Hello! Thank you for your plugin.

One thing I was missing is the ability to collapse the node under the cursor without moving to the directory to collapse it. I've added a video demonstrating what my PR does.

https://github.com/user-attachments/assets/3928adf7-cf0f-473a-a777-2e3917e7730b

I've added a check to prevent collapsing the root. I'm not really sure about the implementation of automatically moving the cursor to the parent directory, so if you think of a better way, please don't hesitate to let me know.

Have a nice day !