### PR TITLE
[FIX] Correct collapse logic for node and parent

### DIFF
--- a/lua/fyler/explorer/actions.lua
+++ b/lua/fyler/explorer/actions.lua
@@ -164,10 +164,16 @@ function M.n_collapse_node(self)
 
     local collapse_target = self.file_tree:find_parent(ref_id)
     if not collapse_target then return end
-    if collapse_target == root_id then return end
-    local focus_ref_id = collapse_target
+    if collapse_target == root_id and not entry.open then return end
+    local focus_ref_id
 
-    self.file_tree:collapse_node(collapse_target)
+    if entry:isdir() and entry.open then
+      self.file_tree:collapse_node(ref_id)
+      focus_ref_id = ref_id
+    else
+      self.file_tree:collapse_node(collapse_target)
+      focus_ref_id = collapse_target
+    end
 
     api.nvim_exec_autocmds("User", {
       pattern = "DispatchRefresh",


### PR DESCRIPTION
- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)

Hello again,

I've improved the logic behind `n_collapse_node` to auto collapse current node if the user is on top of an open directory, and fixed a bug for a child dir in root.