### PR TITLE
fix: missing icons

### DIFF
--- a/lua/fyler/explorer/ui.lua
+++ b/lua/fyler/explorer/ui.lua
@@ -111,7 +111,7 @@ file_tree = UiComponent.new(function(node, width, depth)
   local sorted_items = sort_nodes(node.children)
 
   for _, item in ipairs(sorted_items) do
-    local icon, hl = icon_provider(item.type, item.name)
+    local icon, hl = icon_provider(item.type, item.path)
 
     table.insert(children, create_file_row(item, depth, width, icon, hl))
 


### PR DESCRIPTION
Relying on the filename alone to get the icon isn’t enough, as some LSP's set the filetype based a sub dir:

```lua
vim.filetype.add({
  pattern = { [".*/hypr/.*%.conf"] = "hyprlang" },
})
```

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)
