### PR TITLE
fix: fyler.open

### DIFF
--- a/lua/fyler.lua
+++ b/lua/fyler.lua
@@ -27,7 +27,7 @@ function M.setup(opts)
   local util = require "fyler.lib.util"
 
   M.open = vim.schedule_wrap(function(opts)
-    opts = opts or {};
+    opts = opts or {}
     local dir = opts.dir or fs.cwd()
     local kind = opts.kind or config.values.win.kind
     local instance = explorer.instance(dir)


### PR DESCRIPTION
minimal fix that adds support for calling open without arguments

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)
