### PR TITLE
fix: added missing annotation for `mappings` option

### DIFF
--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -25,6 +25,7 @@ local util = require "fyler.lib.util"
 ---| "SelectTab"
 ---| "SelectVSplit"
 ---| "CollapseAll"
+---| "CollapseNode"
 
 ---@class FylerConfigIndentScope
 ---@field enabled boolean


### PR DESCRIPTION
- [X] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)

The `mappings` option for `setup()` had a missing value in its annotations: `"CollapseNode"`. I've added it to the pertinent alias.