### PR TITLE
ci: specifiad StyLua syntax (and line endings)

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -3,6 +3,8 @@ column_width = 120
 indent_type = "Spaces"
 indent_width = 2
 quote_style = "AutoPreferDouble"
+syntax = "LuaJIT"
+line_endings = "Unix"
 
 [sort_requires]
 enabled = true


### PR DESCRIPTION
- [X] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)

Neovim uses LuaJIT syntax for its configuration. Worry not, as StyLua doesn't get affected by this.