### PR TITLE
ci: add `doc/tags` to ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # Take notes for any potential thing to remember
 .notes
+
+# Docs helptags file
+doc/tags


### PR DESCRIPTION
- [X] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)

The autogenerated helptags file was blocking updating/pulling since it was not ignored. I've added it to `.gitignore`.

This could be a problem for some users, otherwise.