### PR TITLE
docs(README): fixed missing comma in complete reference lua snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ require("fyler").setup({
       -- right
       -- top
       -- bottom
-    }
-  }
+    },
+  },
 
   -- Buffer tracking
   track_current_buffer = true,


### PR DESCRIPTION
- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)

added a critical missing comma,
and then another comma for consistent style.