### PR TITLE
[FIX] Focus current buffer correctly when open tree on Windows

### DIFF
--- a/lua/fyler/explorer/file_tree.lua
+++ b/lua/fyler/explorer/file_tree.lua
@@ -260,6 +260,7 @@ function M:focus_path(path)
   path = fs.normalize(path)
 
   local root_entry = EntryManager.get(self.tree.root.value)
+  root_entry.path = fs.normalize(root_entry.path)
   if not vim.startswith(path, root_entry.path) then
     return nil
   end


### PR DESCRIPTION
On Windows, opening the tree would fail to focus the correct path as the comparison against `root_entry.path` did not succeed due to different path format. This PR normalizes `root_entry.path` in the `focus_path` method before comparison, ensuring that focus works reliably on Windows.

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)