### PR TITLE
fix: Skip Windows absolute paths during file creation

### DIFF
--- a/lua/fyler/explorer.lua
+++ b/lua/fyler/explorer.lua
@@ -384,7 +384,14 @@ local function get_ordered_operations(changes)
 
   for _, dest in ipairs(all_destinations) do
     local current = dest
-    while current and current ~= "." and current ~= "/" and not processed_dirs[current] do
+
+    while
+      current
+      and current ~= "."
+      and current ~= "/"
+      and not current:find "^[A-Za-z]:/"
+      and not processed_dirs[current]
+    do
       if not vim.fn.isdirectory(current) == 1 and not deleted_paths[current] then
         table.insert(dirs_to_create, current)
         processed_dirs[current] = true


### PR DESCRIPTION
Fixes #173 

Previously, directory traversal did not account for Windows absolute paths ending in the form `x:/`, causing an infinite loop during file creation. This update adds a check to skip such paths and prevent the loop.

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)
