### PR TITLE
fix: Don't set cursor in invalid buffer

### DIFF
--- a/lua/fyler/explorer.lua
+++ b/lua/fyler/explorer.lua
@@ -251,7 +251,7 @@ function M:track_buffer(name)
   end
 
   self:dispatch_refresh(function()
-    if not self.win:has_valid_winid() then
+    if not (self.win:has_valid_winid() and self.win:has_valid_bufnr()) then
       return
     end
 


### PR DESCRIPTION
resolves: #197

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)

The error that motivated this fix:
```lua
vim.schedule callback: ....local/share/nvim/lazy/fyler.nvim/lua/fyler/explorer.lua:263: Invalid buffer id: 14
stack traceback:
        [C]: in function 'nvim_buf_get_lines'
        ....local/share/nvim/lazy/fyler.nvim/lua/fyler/explorer.lua:263: in function 'callback'
        ...cal/share/nvim/lazy/fyler.nvim/lua/fyler/lib/ui/init.lua:99: in function <...cal/share/nvim/lazy/fyler.nvim/lua/fyler/lib/ui/init.lua:95>
```

It seems to be triggered when you exit the fyler buffer through some unconventional/unexpected method; through file search with fzf-lua for example