### PR TITLE
feat: add auto indent in Fyler filetype

### DIFF
--- a/lua/fyler/autocmds.lua
+++ b/lua/fyler/autocmds.lua
@@ -72,6 +72,14 @@ function M.setup(config)
       end
     end,
   })
+
+  api.nvim_create_autocmd("FileType", {
+    group = augroup,
+    pattern = { "Fyler" },
+    callback = function()
+      vim.opt_local.indentexpr = "v:lua.require('fyler.explorer.util').fyler_auto_indent()"
+    end,
+  })
 end
 
 return M

--- a/lua/fyler/explorer/util.lua
+++ b/lua/fyler/explorer/util.lua
@@ -28,4 +28,10 @@ function M.parse_name(str)
   end
 end
 
+function M.fyler_auto_indent()
+  local prevlnum = vim.v.lnum - 1
+  local previndent = vim.fn.indent(prevlnum)
+  return previndent
+end
+
 return M


### PR DESCRIPTION
- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)

[ref issue](https://github.com/A7Lavinraj/fyler.nvim/issues/9)
> Pressing o while on opened folder adds a new line, but without indentation. This prompts the creation of the file/folder on the same level as the opened folder, but intention is to create a file inside a folder.

I think it is nice to have a auto indent in explorer