### PR TITLE
fix(explorer): fix indentation display anomaly

### DIFF
--- a/lua/fyler/explorer.lua
+++ b/lua/fyler/explorer.lua
@@ -115,8 +115,8 @@ function M:open(dir, kind)
     autocmds      = {
       ["BufReadCmd"]   = function() self:dispatch_refresh() end,
       ["BufWriteCmd"]  = function() self:synchronize() end,
-      ["CursorMoved"]  = function() self:constrain_cursor() end,
-      ["CursorMovedI"] = function() self:constrain_cursor() end,
+      ["CursorMoved"]  = function() self:constrain_cursor() self:draw_indentscope() end,
+      ["CursorMovedI"] = function() self:constrain_cursor() self:draw_indentscope() end,
       ["TextChanged"]  = function() self:draw_indentscope() end,
       ["TextChangedI"] = function() self:draw_indentscope() end,
       ["WinClosed"]    = function() self:close() end,
@@ -286,7 +286,8 @@ local function process_line(self, ln)
     return
   end
 
-  local indent_depth = math.floor(cur_indent * 0.5)
+  local scrolled_cols = vim.fn.winsaveview().leftcol
+  local indent_depth = math.floor(cur_indent * 0.5) - scrolled_cols
   for i = 1, indent_depth do
     api.nvim_buf_set_extmark(self.win.bufnr, extmark_namespace, ln - 1, 0, {
       hl_mode = "combine",


### PR DESCRIPTION
- Fix the issue where the indentation marker is displayed abnormally when the window width is narrow.

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)

fixed: https://github.com/A7Lavinraj/fyler.nvim/issues/201

before: 
<img width="315" height="127" alt="image" src="https://github.com/user-attachments/assets/2726761d-3266-4e6a-8e78-ea54a5ce49d2" />

after:
<img width="344" height="224" alt="image" src="https://github.com/user-attachments/assets/71ec7905-f6b4-428a-876c-979571b5bd26" />
