### PR TITLE
feat: add configurable delete-to-trash backend #37

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ require("fyler").setup({
   confirm_simple = false,
   -- Replace netrw as default explorer
   default_explorer = false,
+  -- Move deleted files/directories to the system trash
+  delete_to_trash = false,
 
   -- Git integration
   git_status = {
@@ -242,6 +244,11 @@ require("fyler").setup({
   },
 })
 ```
+
+Enable `delete_to_trash` to send deletions to your operating system's trash (macOS `~/.Trash`, Linux XDG Trash, Windows Recycle Bin) instead of removing files permanently.
+Fyler automatically performs a permanent delete if the target already lives inside the trash directory.
+
+**Note**: When moving files across different filesystems (e.g., to a trash directory on a different drive), the operation automatically falls back to copy-then-delete, which may be slower for large files or directories. Windows operations include a 30-second timeout to prevent hanging.
 
 ## Telescope Extension
 

--- a/doc/fyler.txt
+++ b/doc/fyler.txt
@@ -35,6 +35,7 @@ Fyler supports plenty of options to customize. Following are default values
     close_on_select = true,
     confirm_simple = false,
     default_explorer = false,
+    delete_to_trash = false,
     git_status = {
       enabled = true,
       symbols = {
@@ -142,5 +143,9 @@ Fyler supports plenty of options to customize. Following are default values
     },
   }
 <
+
+When `delete_to_trash` is enabled Fyler moves files and directories into the
+operating system trash instead of permanently deleting them. Items that are
+already inside the trash directory are removed permanently.
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -61,6 +61,7 @@ local util = require "fyler.lib.util"
 ---@field close_on_select boolean
 ---@field confirm_simple boolean
 ---@field default_explorer boolean
+---@field delete_to_trash boolean
 ---@field git_status FylerConfigGitStatus
 ---@field hooks FylerConfigHooks
 ---@field icon table<string, string>
@@ -101,6 +102,7 @@ local util = require "fyler.lib.util"
 ---@field close_on_select boolean|nil
 ---@field confirm_simple boolean|nil
 ---@field default_explorer boolean|nil
+---@field delete_to_trash boolean|nil
 ---@field git_status FylerConfigGitStatus|nil
 ---@field hooks FylerSetupOptionsHooks|nil
 ---@field icon_provider FylerConfigIconProvider|nil
@@ -135,6 +137,7 @@ local function defaults()
     close_on_select = true,
     confirm_simple = false,
     default_explorer = false,
+    delete_to_trash = false,
     git_status = {
       enabled = true,
       symbols = {
@@ -323,6 +326,7 @@ function M.setup(opts)
     { M.values.close_on_select, "boolean" },
     { M.values.confirm_simple, "boolean" },
     { M.values.default_explorer, "boolean" },
+    { M.values.delete_to_trash, "boolean" },
     { M.values.git_status, "table" },
     { M.values.hooks, "table" },
     { M.values.hooks.on_delete, "function", true },

--- a/lua/fyler/health/init.lua
+++ b/lua/fyler/health/init.lua
@@ -102,6 +102,11 @@ local function get_config_schema()
       expected = "boolean",
     },
     {
+      path = "config.values.delete_to_trash",
+      value = config.values.delete_to_trash,
+      expected = "boolean",
+    },
+    {
       path = "config.values.git_status",
       value = config.values.git_status,
       expected = "table",

--- a/lua/fyler/lib/fs.lua
+++ b/lua/fyler/lib/fs.lua
@@ -1,5 +1,6 @@
 local List = require "fyler.lib.structs.list"
 local Stack = require "fyler.lib.structs.stack"
+local config = require "fyler.config"
 local hooks = require "fyler.hooks"
 local util = require "fyler.lib.util"
 local M = {}
@@ -31,6 +32,297 @@ end
 
 local function stat_exists(path)
   return not not select(1, uv.fs_stat(path))
+end
+
+local function normalize_for_compare(path)
+  if not path then
+    return nil
+  end
+
+  path = vim.fs.normalize(path)
+  return path and path:gsub("\\", "/") or nil
+end
+
+local function is_descendant(path, parent)
+  local normalized_path = normalize_for_compare(path)
+  local normalized_parent = normalize_for_compare(parent)
+
+  if not normalized_path or not normalized_parent then
+    return false
+  end
+
+  if normalized_path == normalized_parent then
+    return true
+  end
+
+  if normalized_parent:sub(-1) ~= "/" then
+    normalized_parent = normalized_parent .. "/"
+  end
+
+  return normalized_path:sub(1, #normalized_parent) == normalized_parent
+end
+
+local function macos_trash_dir()
+  return M.joinpath(uv.os_homedir(), ".Trash")
+end
+
+local function linux_trash_dirs()
+  local base_dir = vim.env.XDG_DATA_HOME
+  if not base_dir or base_dir == "" then
+    base_dir = M.joinpath(uv.os_homedir(), ".local", "share")
+  end
+
+  local files_dir = M.joinpath(base_dir, "Trash", "files")
+  local info_dir = M.joinpath(base_dir, "Trash", "info")
+  return files_dir, info_dir
+end
+
+local function is_in_system_trash(path)
+  if not path then
+    return false
+  end
+
+  if M.IS_MAC then
+    return is_descendant(path, macos_trash_dir())
+  end
+
+  if M.IS_LINUX then
+    local files_dir, info_dir = linux_trash_dirs()
+    return is_descendant(path, files_dir) or is_descendant(path, info_dir)
+  end
+
+  if M.IS_WINDOWS then
+    local normalized_path = normalize_for_compare(path)
+    -- Check for $RECYCLE.BIN as a path component, not just a substring
+    -- This prevents false positives like "/projects/$recycle.bin.old/"
+    return normalized_path and normalized_path:lower():match "[/\\]%$recycle%.bin[/\\]" ~= nil
+  end
+
+  return false
+end
+
+local function split_filename(filename)
+  local name, ext = filename:match "^(.*)%.([^%.]+)$"
+  if name and name ~= "" then
+    return name, "." .. ext
+  end
+  return filename, ""
+end
+
+local function next_available_name(dir, filename)
+  if not stat_exists(M.joinpath(dir, filename)) then
+    return filename
+  end
+
+  local name, ext = split_filename(filename)
+  local counter = 1
+
+  while true do
+    local candidate = string.format("%s (%d)%s", name, counter, ext)
+    if not stat_exists(M.joinpath(dir, candidate)) then
+      return candidate
+    end
+    counter = counter + 1
+  end
+end
+
+local function url_encode(path)
+  return path:gsub("([^%w%._~/-])", function(char)
+    return string.format("%%%02X", string.byte(char))
+  end)
+end
+
+local function trash_macos(path)
+  local trash_dir = macos_trash_dir()
+  M.create_dir_recursive(trash_dir)
+
+  local base_name = vim.fs.basename(path)
+  local target_name = next_available_name(trash_dir, base_name)
+  local target_path = M.joinpath(trash_dir, target_name)
+
+  local success, rename_err = uv.fs_rename(path, target_path)
+  if not success then
+    -- EXDEV (cross-device link) error - try copy+delete fallback
+    if rename_err and rename_err:match "EXDEV" then
+      local stat = uv.fs_stat(path)
+      if stat and stat.type == "directory" then
+        M.copy_recursive(path, target_path)
+      else
+        local copy_success, copy_err = uv.fs_copyfile(path, target_path)
+        if not copy_success then
+          return false, copy_err or ("Failed to copy to trash: " .. path)
+        end
+      end
+      -- Only remove original after successful copy
+      M.remove_recursive(path)
+      return true
+    end
+    return false, rename_err or ("Failed to move to trash: " .. path)
+  end
+
+  return true
+end
+
+local function trash_linux(path)
+  -- Note: This implementation follows the FreeDesktop.org Trash specification.
+  -- The .trashinfo file is created before moving the file. If the process crashes
+  -- between these operations, the trash may be in an inconsistent state with orphaned
+  -- .trashinfo files. This is imho an acceptable tradeoff for simplicity.
+  local absolute_path = M.abspath(path)
+  local files_dir, info_dir = linux_trash_dirs()
+
+  M.create_dir_recursive(files_dir)
+  M.create_dir_recursive(info_dir)
+
+  local base_name = vim.fs.basename(path)
+  local target_name = next_available_name(files_dir, base_name)
+  local target_path = M.joinpath(files_dir, target_name)
+  local info_path = M.joinpath(info_dir, target_name .. ".trashinfo")
+  local info_contents =
+    string.format("[Trash Info]\nPath=%s\nDeletionDate=%s\n", url_encode(absolute_path), os.date "%Y-%m-%dT%H:%M:%S")
+
+  local info_fd, open_err = uv.fs_open(info_path, "w", 420) -- 0644 (rw-r--r--)
+  if not info_fd then
+    return false, open_err or ("Failed to create trash metadata: " .. info_path)
+  end
+
+  local written, write_err = uv.fs_write(info_fd, info_contents, -1)
+  uv.fs_close(info_fd)
+
+  if not written then
+    uv.fs_unlink(info_path)
+    return false, write_err or ("Failed to write trash metadata: " .. info_path)
+  end
+
+  local success, rename_err = uv.fs_rename(path, target_path)
+  if not success then
+    -- EXDEV (cross-device link) error - try copy+delete fallback
+    if rename_err and rename_err:match "EXDEV" then
+      local stat = uv.fs_stat(path)
+      if stat and stat.type == "directory" then
+        M.copy_recursive(path, target_path)
+      else
+        local copy_success, copy_err = uv.fs_copyfile(path, target_path)
+        if not copy_success then
+          uv.fs_unlink(info_path)
+          return false, copy_err or ("Failed to copy to trash: " .. path)
+        end
+      end
+      -- Only remove original after successful copy
+      M.remove_recursive(path)
+      return true
+    end
+    uv.fs_unlink(info_path)
+    return false, rename_err or ("Failed to move to trash: " .. path)
+  end
+
+  return true
+end
+
+local function ps_quote(path)
+  return "'" .. path:gsub("'", "''") .. "'"
+end
+
+local function trash_windows(path)
+  local absolute_path = M.abspath(path)
+  local quoted_path = ps_quote(absolute_path)
+
+  -- Wrap the operation in a timeout to prevent hanging
+  local script = string.format(
+    [[
+$timeoutSeconds = 30;
+$job = Start-Job -ScriptBlock {
+  Add-Type -AssemblyName Microsoft.VisualBasic;
+  $ErrorActionPreference = 'Stop';
+  $item = Get-Item -LiteralPath %s;
+  if ($item.PSIsContainer) {
+    [Microsoft.VisualBasic.FileIO.FileSystem]::DeleteDirectory(%s, 'OnlyErrorDialogs', 'SendToRecycleBin');
+  } else {
+    [Microsoft.VisualBasic.FileIO.FileSystem]::DeleteFile(%s, 'OnlyErrorDialogs', 'SendToRecycleBin');
+  }
+};
+$completed = Wait-Job -Job $job -Timeout $timeoutSeconds;
+if ($completed) {
+  $result = Receive-Job -Job $job -ErrorAction SilentlyContinue -ErrorVariable jobError;
+  Remove-Job -Job $job -Force;
+  if ($jobError) {
+    Write-Error $jobError;
+    exit 1;
+  }
+} else {
+  Remove-Job -Job $job -Force;
+  Write-Error 'Operation timed out after 30 seconds';
+  exit 1;
+}
+]],
+    quoted_path,
+    quoted_path,
+    quoted_path
+  )
+
+  local result = vim.fn.system {
+    "powershell",
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    script,
+  }
+
+  if vim.v.shell_error ~= 0 then
+    -- Clean up error message for better readability
+    local error_msg = result and result:gsub("^%s+", ""):gsub("%s+$", "") or ""
+    if error_msg == "" then
+      error_msg = "Failed to move to recycle bin: " .. absolute_path
+    end
+    return false, error_msg
+  end
+
+  return true
+end
+
+local default_trash_backend = {}
+
+function default_trash_backend.is_in_trash(path)
+  return is_in_system_trash(path)
+end
+
+function default_trash_backend.move(path)
+  local stat = uv.fs_stat(path)
+  if not stat then
+    return false, "File or directory does not exist: " .. path
+  end
+
+  if M.IS_MAC then
+    return trash_macos(path)
+  end
+
+  if M.IS_LINUX then
+    return trash_linux(path)
+  end
+
+  if M.IS_WINDOWS then
+    return trash_windows(path)
+  end
+
+  return false, "Unsupported platform for trash operation"
+end
+
+M._trash_backend = default_trash_backend
+
+function M.trash(path)
+  return M._trash_backend.move(path)
+end
+
+function M.set_trash_backend(backend)
+  assert(type(backend) == "table", "Trash backend must be a table")
+  assert(type(backend.move) == "function", "Trash backend must implement move")
+  assert(type(backend.is_in_trash) == "function", "Trash backend must implement is_in_trash")
+
+  M._trash_backend = backend
+end
+
+function M.reset_trash_backend()
+  M._trash_backend = default_trash_backend
 end
 
 function M.exists(path)
@@ -247,7 +539,17 @@ function M.create(path)
 end
 
 function M.delete(path)
-  M.remove_recursive(path)
+  local should_trash = config.values and config.values.delete_to_trash
+  local absolute_path = vim.fn.fnamemodify(path, ":p")
+  local backend = M._trash_backend
+
+  if should_trash and backend and not backend.is_in_trash(absolute_path) then
+    local success, err = backend.move(absolute_path)
+    assert(success, err or ("Failed to move to trash: " .. path))
+  else
+    M.remove_recursive(path)
+  end
+
   vim.schedule(function()
     hooks.on_delete(path)
   end)


### PR DESCRIPTION
  - add delete_to_trash option and document/validate it
  - implement a reusable trash backend with macOS/Linux (freedesktop .trashinfo) / Windows specifics, detect existing trash paths, and expose set_trash_backend + reset_trash_backend for custom integrations or tests
  - keep permanent delete fallback when the target already lives in the trash directory
  - update docs and healthcheck
  - extend the fs tests with backend stubs plus Linux XDG smoke tests
  - delete_to_trash default is false to keep backwards compatibility

I have chosen to implement the flag rather than a custom delete function mentioned in the issue because it is simpler for the user and does not depend on other tools

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)

Full disclosure: Supported by LLM