### PR TITLE
[FIX] Correct directory creation behavior on Windows

### DIFF
--- a/lua/fyler/lib/path.lua
+++ b/lua/fyler/lib/path.lua
@@ -55,7 +55,7 @@ function Path.new(path)
 
   local instance = {
     _path = absolute,
-    _sep = Path.is_windows() and "\\" or "/",
+    _sep = "/",
   }
 
   setmetatable(instance, Path)


### PR DESCRIPTION
According to the implementation of `vim.fs.abspath`, when converting a path to an absolute one, the returned value is already normalized, so we can skip checking the OS for separator. This fix the issue where directory cannot be created on Windows.

See: https://github.com/neovim/neovim/blob/4110e6730a2e125c3656a40362eb3d40527ac063/runtime/lua/vim/fs.lua#L755

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)
