### PR TITLE
feat(hl): add FylerNormalNC and mark hl groups as default

### DIFF
--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -265,7 +265,7 @@ local function defaults()
             cursorline = false,
             number = false,
             relativenumber = false,
-            winhighlight = "Normal:FylerNormal",
+            winhighlight = "Normal:FylerNormal,NormalNC:FylerNormalNC",
             wrap = false,
           },
         },

--- a/lua/fyler/inputs/confirm.lua
+++ b/lua/fyler/inputs/confirm.lua
@@ -66,7 +66,7 @@ function Confirm:open(options, message, on_submit)
     top        = top,
     width      = width,
     win_opts   = {
-      winhighlight = "Normal:FylerNormal"
+      winhighlight = "Normal:FylerNormal,NormalNC:FylerNormalNC"
     }
   }
   -- stylua: ignore end

--- a/lua/fyler/lib/hl.lua
+++ b/lua/fyler/lib/hl.lua
@@ -92,13 +92,14 @@ function M.setup()
     FylerBorder          = { link = "FylerNormal" },
     FylerIndentMarker    = { link = "FylerGrey" },
     FylerNormal          = { link = "Normal" },
+    FylerNormalNC        = { link = "NormalNC" },
   }
   -- stylua: ignore end
 
   require("fyler.hooks").on_highlight(hl_groups, palette)
 
   for k, v in pairs(hl_groups) do
-    vim.api.nvim_set_hl(0, k, v)
+    vim.api.nvim_set_hl(0, k, vim.tbl_extend("keep", v, { default = true }))
   end
 end
 


### PR DESCRIPTION
- `FylerNormalNC` applies when the fyler window is not focused
- set `default = true` for hl group definitions so that third-party colorschemes can override them

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)
