### PR TITLE
feat: default winfixwidth and winfixheight to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Fyler.nvim works out of the box with sensible defaults. Here's the complete conf
           relativenumber = false,
           winhighlight = "Normal:FylerNormal",
           wrap = false,
+          winfixwidth = true,
+          winfixheight = true,
         },
       },
     },

--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -267,6 +267,8 @@ local function defaults()
             relativenumber = false,
             winhighlight = "Normal:FylerNormal,NormalNC:FylerNormalNC",
             wrap = false,
+            winfixwidth = true,
+            winfixheight = true,
           },
         },
       },


### PR DESCRIPTION
ensures fyler windows stay fixed when other nvim windows are opened/closed/resized

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)
