### PR TITLE
fix: make winfixwidth/winfixheight kind-specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,24 +198,36 @@ Fyler.nvim works out of the box with sensible defaults. Here's the complete conf
           },
           split_above_all = {
             height = "70%",
+            win_opts = {
+              winfixheight = true, -- keep the window height fixed when other windows resize
+            },
           },
           split_below = {
             height = "70%",
           },
           split_below_all = {
             height = "70%",
+            win_opts = {
+              winfixheight = true,
+            },
           },
           split_left = {
             width = "70%",
           },
           split_left_most = {
             width = "30%",
+            win_opts = {
+              winfixwidth = true, -- keep the window width fixed when other windows resize
+            },
           },
           split_right = {
             width = "30%",
           },
           split_right_most = {
             width = "30%",
+            win_opts = {
+              winfixwidth = true,
+            },
           },
         },
         win_opts = {
@@ -226,8 +238,6 @@ Fyler.nvim works out of the box with sensible defaults. Here's the complete conf
           relativenumber = false,
           winhighlight = "Normal:FylerNormal,NormalNC:FylerNormalNC",
           wrap = false,
-          winfixwidth = true,
-          winfixheight = true,
         },
       },
     },

--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -115,6 +115,7 @@ local DEPRECATION_RULES = {
 ---@field width string|number|nil
 ---@field top string|number|nil
 ---@field left string|number|nil
+---@field win_opts table<string, any>|nil
 
 ---@class FylerConfigWin
 ---@field border FylerConfigBorder|string[]
@@ -239,24 +240,36 @@ local function defaults()
             },
             split_above_all = {
               height = "70%",
+              win_opts = {
+                winfixheight = true,
+              },
             },
             split_below = {
               height = "70%",
             },
             split_below_all = {
               height = "70%",
+              win_opts = {
+                winfixheight = true,
+              },
             },
             split_left = {
               width = "70%",
             },
             split_left_most = {
               width = "30%",
+              win_opts = {
+                winfixwidth = true,
+              },
             },
             split_right = {
               width = "30%",
             },
             split_right_most = {
               width = "30%",
+              win_opts = {
+                winfixwidth = true,
+              },
             },
           },
           win_opts = {
@@ -267,8 +280,6 @@ local function defaults()
             relativenumber = false,
             winhighlight = "Normal:FylerNormal,NormalNC:FylerNormalNC",
             wrap = false,
-            winfixwidth = true,
-            winfixheight = true,
           },
         },
       },


### PR DESCRIPTION
Move default winfixwidth and winfixheight from general win_opts to kind-specific win_opts tables so they only apply to `split_{left/right}_most` and `split_{above/below}_all`, preventing inappropriate window size fixing on other kinds

We don't need any special handling for the new `win_opts` tables in the kinds, because the following line already performs the desired deep merge of the tables:

```lua
view.win = require("fyler.lib.util").tbl_merge_force(view.win, view.win.kinds[kind or view.win.kind])
``` 

Ref #216

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)
