### PR TITLE
fix(winpick): do nothing if no window is selected

### DIFF
--- a/lua/fyler/views/finder/actions.lua
+++ b/lua/fyler/views/finder/actions.lua
@@ -34,7 +34,9 @@ local function _select(self, opener)
   end
 
   local function open_in_window(winid)
-    winid = winid or self.win.winid
+    if not winid then
+      return
+    end
     vim.api.nvim_set_current_win(winid)
     opener(entry.path)
   end


### PR DESCRIPTION
Previously, if no window was picked (e.g. by pressing `<esc>`), the file would be opened in the fyler window, which I don't think is desired.

- [X] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)
