### PR TITLE
fix: normalize path when navigating with alternate buf on Windows

### DIFF
--- a/lua/fyler/views/finder/files/init.lua
+++ b/lua/fyler/views/finder/files/init.lua
@@ -44,11 +44,13 @@ end
 ---@param path string
 ---@return string[]|nil
 function Files:path_to_segments(path)
-  if not vim.startswith(path, self.root_path) then
+  local normalized = Path.new(path):normalize()
+
+  if not vim.startswith(normalized, self.root_path) then
     return nil
   end
 
-  local relative = path:sub(#self.root_path + 1)
+  local relative = normalized:sub(#self.root_path + 1)
   if relative:sub(1, 1) == "/" then
     relative = relative:sub(2)
   end

--- a/lua/fyler/views/finder/init.lua
+++ b/lua/fyler/views/finder/init.lua
@@ -108,7 +108,7 @@ function Finder:load_with(kind, bufname)
       self:dispatch_refresh(function()
         local altbufnr = vim.fn.bufnr("#")
         if config.values.views.finder.follow_current_file and altbufnr ~= -1 then
-          self:navigate(Path.new(vim.api.nvim_buf_get_name(altbufnr)):normalize())
+          self:navigate(vim.api.nvim_buf_get_name(altbufnr))
         end
       end)
     end,


### PR DESCRIPTION
- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)

On Windows, the path of the alternate buffer must be normalized to ensure the currently opened file is correctly focused in the Fyler window when it is open.

Tested on both macOS and Windows.