### PR TITLE
fix: proper range handling for :Fyler command

### DIFF
--- a/lua/fyler/lib/util.lua
+++ b/lua/fyler/lib/util.lua
@@ -234,7 +234,7 @@ function M.cmd_history(index)
   return vim.fn.histget("cmd", index or -1)
 end
 
----@return string|nil
+---@return string[]|nil
 function M.get_visual_selection()
   local start_mark = vim.api.nvim_buf_get_mark(0, "<")
   local end_mark = vim.api.nvim_buf_get_mark(0, ">")
@@ -243,7 +243,7 @@ function M.get_visual_selection()
   if start_row == 0 or end_row == 0 then
     return nil
   end
-  return table.concat(vim.api.nvim_buf_get_text(0, start_row - 1, start_col, end_row - 1, end_col + 1, {}))
+  return vim.api.nvim_buf_get_text(0, start_row - 1, start_col, end_row - 1, end_col + 1, {})
 end
 
 return M

--- a/plugin/fyler.lua
+++ b/plugin/fyler.lua
@@ -6,7 +6,46 @@ vim.api.nvim_create_user_command("Fyler", function(args)
     opts[k] = v
   end
 
-  require("fyler").open(util.tbl_merge_keep(opts, { dir = util.get_visual_selection() }))
+  if opts.dir == nil then
+    ---@type string[]|nil
+    local range_lines = nil
+
+    -- Check if the command was called from a visual mode mapping
+    local mode = vim.fn.mode()
+    if mode == "v" or mode == "V" or mode == vim.api.nvim_replace_termcodes("<C-v>", true, true, true) then
+      -- We need to switch out of visual mode in order for the '> and '< marks
+      -- to be set to the correct lines.
+      -- Calling `"normal! " .. mode` achieves this by switching to normal mode
+      -- and then immediately back to the original mode.
+      vim.cmd("normal! " .. mode)
+      range_lines = util.get_visual_selection()
+    elseif args.range > 0 then
+      -- Check if range start and end line are the same as the last visual selection.
+      -- If so, use the visual selection including column offsets.
+      -- This may have unexpected behavior if the user explicitly passes a range that
+      -- matches the last visual selection and expects line-wise behavior.
+      -- This is a limitation of Neovim's command ranges: https://github.com/neovim/neovim/issues/22297
+      local visual_start_row = vim.api.nvim_buf_get_mark(0, "<")[1]
+      local visual_end_row = vim.api.nvim_buf_get_mark(0, ">")[1]
+      if visual_start_row == args.line1 and visual_end_row == args.line2 then
+        range_lines = util.get_visual_selection()
+      else
+        range_lines = vim.api.nvim_buf_get_lines(0, args.line1 - 1, (args.line2 or args.line1), false)
+      end
+    end
+
+    if range_lines and #range_lines > 0 then
+      -- Just use the first line of the range - it doesn't make sense to use multiple lines as a directory path.
+      -- In the future, we may want to treat multiple lines as multiple directories to open, but it's not clear how
+      -- opening multiple directories would work currently.
+      local dir = vim.trim(range_lines[1])
+      if dir ~= "" then
+        opts.dir = dir
+      end
+    end
+  end
+
+  require("fyler").open(opts)
 end, {
   nargs = "*",
   range = true,


### PR DESCRIPTION
Previously, we were *always* using the last visual selection as the directory, even if the Fyler command was not called with a range or from a visual mode mapping. We were also ignoring the range passed to the command if it was different from the last visual selection (e.g. `:2,3Fyler`).

This improves the behavior by:

- Checking if the command was called directly from visual mode, and if so, using the visual selection (including column offsets) as the directory (note: this could possibly be undesired if the user calls `:Fyler` while visual mode is active but they don't want to use the visual selection - in which case, they can explicitly set `dir=` to their desired dir).
- Otherwise, checking if the passed range matches the last visual selection, and if so, using the visual selection (including column offsets) as the directory. This is to support the case of `:'<,'>Fyler`
- Otherwise, if a line-wise range was passed, using the lines as the directory.

In all of the above cases, if the range includes multiple lines, we only use the first line of the range. While directory paths can sometimes contain newlines, this is exceedingly rare. In the future, we may want to treat the full range as multiple directories to open, but it's not clear how opening multiple directories would work currently.

Fixes #265

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)
