### PR TITLE
feat: Add close_on_leave option for float window

### DIFF
--- a/doc/fyler.txt
+++ b/doc/fyler.txt
@@ -83,6 +83,8 @@ To know more about plugin customization. visit:
       -- View is a plugin component with dedicated window, UI and config
       views = {
         finder = {
+          -- Close float window when leaving the buffer
+          close_on_leave = false,
           -- Automatically closes after open a file
           close_on_select = true,
           -- Skip confirmation for simple operations

--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -96,6 +96,7 @@ local DEPRECATION_RULES = {
 ---@field win_opts table<string, any>
 
 ---@class FylerConfigViewsFinder
+---@field close_on_leave boolean
 ---@field close_on_select boolean
 ---@field confirm_simple boolean
 ---@field default_explorer boolean
@@ -167,6 +168,8 @@ function config.defaults()
     -- View is a plugin component with dedicated window, UI and config
     views = {
       finder = {
+        -- Close float window when leaving the buffer
+        close_on_leave = false,
         -- Automatically closes after open a file
         close_on_select = true,
         -- Skip confirmation for simple operations

--- a/lua/fyler/views/finder/init.lua
+++ b/lua/fyler/views/finder/init.lua
@@ -63,6 +63,17 @@ function Finder:open(kind)
       ["BufReadCmd"] = function() self:dispatch_refresh() end,
       ["BufWriteCmd"] = function() self:dispatch_mutation() end,
       [{"CursorMoved","CursorMovedI"}] = function() self:clamp_cursor() end,
+      ["BufLeave"] = function()
+        if not view_cfg.close_on_leave then return end
+        if self.win.kind ~= "float" then return end
+        vim.schedule(function()
+          if not self:isopen() then return end
+          -- Don't close if focus moved to another float (e.g., confirmation)
+          local win_config = vim.api.nvim_win_get_config(0)
+          if win_config.relative ~= "" then return end
+          self:close()
+        end)
+      end,
     },
     border        = view_cfg.win.border,
     bufname       = self.uri,

--- a/tests/unit/test_setup.lua
+++ b/tests/unit/test_setup.lua
@@ -58,6 +58,7 @@ T["Setup Config"] = function()
   expect_config("integrations.icon", "mini_icons")
   expect_config("integrations.winpick", "none")
 
+  expect_config("views.finder.close_on_leave", false)
   expect_config("views.finder.close_on_select", true)
   expect_config("views.finder.confirm_simple", false)
   expect_config("views.finder.default_explorer", false)


### PR DESCRIPTION
## Summary

Hi! This PR adds a new `close_on_leave` option that automatically closes a float window when it loses focus. 

## Changes

- Add `close_on_leave` option to `views.finder` config (default: `false`)
- When enabled and the window kind is `float`, the window closes automatically on `BufLeave`
- Confirmation dialogs are excluded from this behavior using `vim.schedule` + `win_config.relative` check
- Updated documentation

## Note

**Naming:** The option name `close_on_leave` might suggest it applies to all window kinds, but it currently only affects float windows. This is intentional: I assumed users with split windows would likely prefer them to stay open when switching focus.

**Float-to-float transitions:** To prevent the window from closing when opening confirmation dialogs, I implemented it so that transitions to any float window won't trigger the close. This is implicit behavior - it works correctly for confirmations, but also means the window won't close when focusing other float windows (e.g., from other plugins). Let me know if this approach is acceptable or if you'd prefer a more explicit check.

If you'd prefer a different naming convention (e.g., `float_close_on_leave`) or want this behavior extended to split windows as well, I'm happy to adjust.
