### PR TITLE
Fix conditional logic for buffer filetype check

### DIFF
--- a/lua/fyler/autocmds.lua
+++ b/lua/fyler/autocmds.lua
@@ -66,7 +66,7 @@ function M.setup(config)
         if helper.is_protocol_uri(arg.file) or arg.file == "" then return end
 
         vim.schedule(function()
-          if not util.get_buf_option(arg.buf, "filetype") ~= "fyler" then fyler.navigate(arg.file) end
+          if util.get_buf_option(arg.buf, "filetype") ~= "fyler" then fyler.navigate(arg.file) end
         end)
       end,
     })


### PR DESCRIPTION
- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)

Tested fixing this conditional logic and it fixes the bug with `folow_current_file` not working.