### PR TITLE
fix(resolver): prevent spurious actions on symlink directory children

### DIFF
--- a/lua/fyler/views/finder/files/resolver.lua
+++ b/lua/fyler/views/finder/files/resolver.lua
@@ -43,7 +43,8 @@ function Resolver:_parse_buffer()
     end
 
     local current_parent = parent_stack:top()
-    local parent_path = manager.get(current_parent.node.ref_id).path
+    local parent_entry = manager.get(current_parent.node.ref_id)
+    local parent_path = parent_entry.link or parent_entry.path
 
     local child_node = {
       ref_id = entry_ref_id,


### PR DESCRIPTION
This addresses a missed case from #291.

`_parse_buffer` was still using `entry.path` (resolved path) in some cases, which could lead to path mismatches against `_generate_actions` and trigger false MOVE / DELETE actions for symlink children.

Prefer `entry.link` when available to keep path semantics consistent.

No behavior change for non-symlink entries.

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)
