### PR TITLE
fix(win): restore user window options after hiding

### DIFF
--- a/lua/fyler.lua
+++ b/lua/fyler.lua
@@ -72,7 +72,11 @@ function M.setup(opts)
   -- Fyler.API: Opens finder view with provided options
   M.open = function(args)
     args = args or {}
-    finder.open(args.dir, args.kind)
+    -- If dir is provided, set it as current dir first
+    if args.dir then
+      finder.set_current_dir(args.dir)
+    end
+    finder.open(args.kind)
   end
 
   -- Fyler.API: Closes current finder view
@@ -81,7 +85,11 @@ function M.setup(opts)
   -- Fyler.API: Toggles finder view with provided options
   M.toggle = function(args)
     args = args or {}
-    finder.toggle(args.dir, args.kind)
+    -- If dir is provided, set it as current dir first
+    if args.dir then
+      finder.set_current_dir(args.dir)
+    end
+    finder.toggle(args.kind)
   end
 
   -- Fyler.API: Focus finder view
@@ -89,6 +97,12 @@ function M.setup(opts)
 
   -- Fyler.API: Focuses given file path
   M.navigate = function(path) finder.navigate(path) end
+
+  -- Fyler.API: Set global current working directory
+  M.set_current_dir = finder.set_current_dir
+
+  -- Fyler.API: Get global current working directory
+  M.get_current_dir = finder.get_current_dir
 end
 
 return M

--- a/lua/fyler/autocmds.lua
+++ b/lua/fyler/autocmds.lua
@@ -39,7 +39,7 @@ function M.setup(config)
 
     vim.api.nvim_create_autocmd({ "BufReadCmd", "SessionLoadPost" }, {
       group = augroup,
-      pattern = "fyler://%d+//*",
+      pattern = "fyler://*",
       desc = "Open fyler protocol URIs",
       callback = function(args)
         local bufname = vim.api.nvim_buf_get_name(args.buf)

--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -57,6 +57,9 @@ local DEPRECATION_RULES = {
 ---| "SelectVSplit"
 ---| "CollapseAll"
 ---| "CollapseNode"
+---| "SetCwdHere"
+---| "SetCwdToParent"
+---| "SetCwdToNode"
 
 ---@class FylerConfigIndentScope
 ---@field enabled boolean

--- a/lua/fyler/inputs/confirm.lua
+++ b/lua/fyler/inputs/confirm.lua
@@ -5,8 +5,10 @@ local util = require("fyler.lib.util")
 local Confirm = {}
 Confirm.__index = Confirm
 
+local FOOTER = " Want to continue? (y|n) "
+
 local function resolve_dim(width, height)
-  width = math.max(25, math.min(vim.o.columns, width)) + 2
+  width = math.max(#FOOTER, math.min(vim.o.columns, width)) + 2
   height = math.max(1, math.min(16, height))
   local left = math.floor((vim.o.columns - width) * 0.5)
   local top = math.floor((vim.o.lines - height) * 0.5)
@@ -24,10 +26,16 @@ function Confirm:open(options, message, onsubmit)
     left       = left,
     top        = top,
     border     = vim.o.winborder == "" and "rounded" or vim.o.winborder,
-    footer     = " Want to continue? (y|n) ",
+    footer     = FOOTER,
     footer_pos = "center",
     buf_opts   = { modifiable = false },
-    win_opts   = { winhighlight = "Normal:FylerNormal,NormalNC:FylerNormalNC" },
+    win_opts   = {
+      winhighlight = "Normal:FylerNormal,NormalNC:FylerNormalNC",
+      number = false,
+      relativenumber = false,
+      signcolumn = "no",
+      foldcolumn = "0",
+    },
     mappings   = {
       [{ 'y', 'o', '<Enter>' }] = function()
         self.window:hide()

--- a/lua/fyler/integrations/icon/nvim_web_devicons.lua
+++ b/lua/fyler/integrations/icon/nvim_web_devicons.lua
@@ -5,7 +5,7 @@ function M.get(type, path)
   local ok, devicons = pcall(require, "nvim-web-devicons")
   assert(ok, "nvim-web-devicons are not installed or not loaded")
 
-  local icon, hl = devicons.get_icon(vim.fn.fnamemodify(path, ":t"), vim.fn.fnamemodify(path, ":e"))
+  local icon, hl = devicons.get_icon(vim.fn.fnamemodify(path, ":t"))
   icon = (type == "directory" and "" or (icon or ""))
   hl = hl or (type == "directory" and "Fylerblue" or "")
 

--- a/lua/fyler/lib/git.lua
+++ b/lua/fyler/lib/git.lua
@@ -50,9 +50,22 @@ function M.map_entries_async(root_dir, entries, _next)
       local result = util.tbl_map(
         entries,
         function(e)
+          local status = status_map[e]
+          -- If this entry has no direct status, check if it's inside an
+          -- untracked directory. git status --porcelain only reports the
+          -- top-level directory for fully untracked trees, so child entries
+          -- won't have their own status in the map.
+          if not status then
+            for dir_path, dir_status in pairs(status_map) do
+              if dir_status == "??" and vim.startswith(e, dir_path .. "/") then
+                status = dir_status
+                break
+              end
+            end
+          end
           return {
-            config.values.views.finder.columns.git.symbols[icon_map[status_map[e]]] or "",
-            hl_map[icon_map[status_map[e]]],
+            config.values.views.finder.columns.git.symbols[icon_map[status]] or "",
+            hl_map[icon_map[status]],
           }
         end
       )
@@ -76,7 +89,8 @@ function M.build_modified_lookup_for_async(dir, _next)
       for _, line in process:stdout_iter() do
         if line ~= "" then
           local symbol = line:sub(1, 2)
-          local path = Path.new(dir):join(line:sub(4)):os_path()
+          local raw = line:sub(4):gsub("/$", "")
+          local path = Path.new(dir):join(raw):os_path()
           lookup[path] = symbol
         end
       end

--- a/lua/fyler/lib/git.lua
+++ b/lua/fyler/lib/git.lua
@@ -43,6 +43,17 @@ local hl_map = {
   Ignored = "FylerGitIgnored",
 }
 
+local icon_hl_map = {
+  Untracked = "FylerGitIconUntracked",
+  Added = "FylerGitIconAdded",
+  Modified = "FylerGitIconModified",
+  Deleted = "FylerGitIconDeleted",
+  Renamed = "FylerGitIconRenamed",
+  Copied = "FylerGitIconCopied",
+  Conflict = "FylerGitIconConflict",
+  Ignored = "FylerGitIconIgnored",
+}
+
 function M.map_entries_async(root_dir, entries, _next)
   M.build_modified_lookup_for_async(root_dir, function(modified_lookup)
     M.build_ignored_lookup_for_async(root_dir, entries, function(ignored_lookup)
@@ -50,9 +61,11 @@ function M.map_entries_async(root_dir, entries, _next)
       local result = util.tbl_map(
         entries,
         function(e)
+          local status = status_map[e]
           return {
-            config.values.views.finder.columns.git.symbols[icon_map[status_map[e]]] or "",
-            hl_map[icon_map[status_map[e]]],
+            config.values.views.finder.columns.git.symbols[icon_map[status]] or "",
+            icon_hl_map[icon_map[status]],
+            hl_map[icon_map[status]],
           }
         end
       )

--- a/lua/fyler/lib/hl.lua
+++ b/lua/fyler/lib/hl.lua
@@ -82,6 +82,7 @@ function M.setup()
 
     FylerGitAdded        = { fg = palette.green },
     FylerGitConflict     = { fg = palette.red },
+    FylerGitCopied       = { fg = palette.yellow },
     FylerGitDeleted      = { fg = palette.red },
     FylerGitIgnored      = { fg = palette.grey },
     FylerGitModified     = { fg = palette.yellow },
@@ -89,6 +90,17 @@ function M.setup()
     FylerGitStaged       = { fg = palette.green },
     FylerGitUnstaged     = { fg = palette.orange },
     FylerGitUntracked    = { fg = palette.cyan },
+
+    FylerGitIconAdded     = { link = "FylerGitAdded" },
+    FylerGitIconConflict  = { link = "FylerGitConflict" },
+    FylerGitIconCopied    = { link = "FylerGitCopied" },
+    FylerGitIconDeleted   = { link = "FylerGitDeleted" },
+    FylerGitIconIgnored   = { link = "FylerGitIgnored" },
+    FylerGitIconModified  = { link = "FylerGitModified" },
+    FylerGitIconRenamed   = { link = "FylerGitRenamed" },
+    FylerGitIconStaged    = { link = "FylerGitStaged" },
+    FylerGitIconUnstaged  = { link = "FylerGitUnstaged" },
+    FylerGitIconUntracked = { link = "FylerGitUntracked" },
 
     FylerWinPick         = { fg = palette.white, bg = palette.blue },
 

--- a/lua/fyler/lib/win.lua
+++ b/lua/fyler/lib/win.lua
@@ -145,9 +145,7 @@ function Win:update_title(title)
 end
 
 function Win:config()
-  local winconfig = {
-    style = "minimal",
-  }
+  local winconfig = {}
 
   ---@param dim integer|string
   ---@return integer|nil, boolean|nil
@@ -304,6 +302,14 @@ function Win:show()
     vim.keymap.set("n", k, v, mappings_opts)
   end
 
+  -- Save original window options before overriding, so they can be restored
+  -- when the fyler window is hidden (important for `replace` kind where the
+  -- same window is reused for the opened file).
+  self._saved_win_opts = {}
+  for option, _ in pairs(self.win_opts or {}) do
+    self._saved_win_opts[option] = util.get_win_option(self.winid, option)
+  end
+
   for option, value in pairs(self.win_opts or {}) do
     util.set_win_option(self.winid, option, value)
   end
@@ -333,6 +339,15 @@ end
 
 function Win:hide()
   if self.kind:match("^replace") then
+    -- Restore original window options before switching buffers, so the opened
+    -- file respects the user's settings (e.g. relativenumber, cursorline).
+    if self._saved_win_opts and self:has_valid_winid() then
+      for option, value in pairs(self._saved_win_opts) do
+        util.set_win_option(self.winid, option, value)
+      end
+      self._saved_win_opts = nil
+    end
+
     local altbufnr = vim.fn.bufnr("#")
     if altbufnr == -1 or altbufnr == self.bufnr then
       util.try(vim.cmd.enew)

--- a/lua/fyler/lib/win.lua
+++ b/lua/fyler/lib/win.lua
@@ -110,6 +110,7 @@ function Win:set_lines(start, finish, lines)
   self:set_local_buf_option("undolevels", -1)
 
   vim.api.nvim_buf_clear_namespace(self.bufnr, self.namespace, 0, -1)
+  self._extmark_ids = {}
   vim.api.nvim_buf_set_lines(self.bufnr, start, finish, false, lines)
 
   if not was_modifiable then self:set_local_buf_option("modifiable", false) end
@@ -122,7 +123,13 @@ end
 ---@param col integer
 ---@param options vim.api.keyset.set_extmark
 function Win:set_extmark(row, col, options)
-  if self:has_valid_bufnr() then vim.api.nvim_buf_set_extmark(self.bufnr, self.namespace, row, col, options) end
+  if not self:has_valid_bufnr() then return end
+
+  local id = vim.api.nvim_buf_set_extmark(self.bufnr, self.namespace, row, col, options)
+
+  if not self._extmark_ids then self._extmark_ids = {} end
+  if not self._extmark_ids[row] then self._extmark_ids[row] = {} end
+  table.insert(self._extmark_ids[row], id)
 end
 
 function Win:focus()
@@ -329,6 +336,31 @@ function Win:show()
   end
 
   vim.api.nvim_buf_attach(self.bufnr, false, {
+    on_lines = function(_, bufnr, _, firstline, lastline, new_lastline)
+      if not self._extmark_ids then return end
+
+      local old_count = lastline - firstline
+      local new_count = new_lastline - firstline
+
+      if old_count == new_count then return end
+
+      local new_map = {}
+      for line, ids in pairs(self._extmark_ids) do
+        if line >= firstline and line < firstline + old_count and old_count > new_count then
+          -- This line was deleted — remove its extmarks
+          for _, id in ipairs(ids) do
+            pcall(vim.api.nvim_buf_del_extmark, bufnr, self.namespace, id)
+          end
+        elseif line >= firstline + old_count then
+          -- Shift lines that were below the changed range
+          local new_line = line + (new_count - old_count)
+          new_map[new_line] = ids
+        else
+          new_map[line] = ids
+        end
+      end
+      self._extmark_ids = new_map
+    end,
     on_detach = function()
       if self.autocmds or self.user_autocmds then pcall(vim.api.nvim_del_augroup_by_id, self.augroup) end
     end,

--- a/lua/fyler/views/finder/actions.lua
+++ b/lua/fyler/views/finder/actions.lua
@@ -140,6 +140,8 @@ function M.n_goto_parent(self)
   return function()
     local parent_dir = Path.new(self:getcwd()):parent():posix_path()
     if parent_dir == self:getcwd() then return end
+    
+    -- Navigate within the tree (don't change tree root)
     self:change_root(parent_dir):dispatch_refresh({ force_update = true })
   end
 end
@@ -148,6 +150,8 @@ end
 function M.n_goto_cwd(self)
   return function()
     if self:getrwd() == self:getcwd() then return end
+    
+    -- Navigate within the tree (don't change tree root)
     self:change_root(self:getrwd()):dispatch_refresh({ force_update = true })
   end
 end
@@ -162,6 +166,7 @@ function M.n_goto_node(self)
     if not entry then return end
 
     if entry.type == "directory" then
+      -- Navigate within the tree (don't change tree root)
       self:change_root(entry.path):dispatch_refresh({ force_update = true })
     else
       self:action_call("n_select")
@@ -199,6 +204,51 @@ function M.n_collapse_node(self)
         if self:isopen() then vim.fn.search(string.format("/%05d", focus_ref_id)) end
       end,
     })
+  end
+end
+
+---@param self Finder
+function M.n_set_cwd_to_parent(self)
+  return function()
+    local parent_dir = Path.new(self:getcwd()):parent():posix_path()
+    if parent_dir == self:getcwd() then return end
+    
+    local finder_module = require("fyler.views.finder")
+    finder_module.set_current_dir(parent_dir)
+  end
+end
+
+---@param self Finder
+function M.n_set_cwd_here(self)
+  return function()
+    local finder_module = require("fyler.views.finder")
+    local current_cwd = finder_module.get_current_dir()
+    
+    if current_cwd == self:getcwd() then return end
+    
+    finder_module.set_current_dir(self:getcwd())
+  end
+end
+
+---@param self Finder
+function M.n_set_cwd_to_node(self)
+  return function()
+    local ref_id = helper.parse_ref_id(vim.api.nvim_get_current_line())
+    if not ref_id then return end
+
+    local entry = self.files:node_entry(ref_id)
+    if not entry then return end
+
+    local target_path
+    if entry.type == "directory" then
+      target_path = entry.path
+    else
+      -- For files, use the parent directory
+      target_path = Path.new(entry.path):parent():posix_path()
+    end
+    
+    local finder_module = require("fyler.views.finder")
+    finder_module.set_current_dir(target_path)
   end
 end
 

--- a/lua/fyler/views/finder/helper.lua
+++ b/lua/fyler/views/finder/helper.lua
@@ -2,35 +2,31 @@ local M = {}
 
 ---@param uri string|nil
 ---@return boolean
-function M.is_protocol_uri(uri) return uri and (not not uri:match("^fyler://%d+")) or false end
+function M.is_protocol_uri(uri) return uri and (not not uri:match("^fyler://")) or false end
 
 ---@param dir string
----@param tab string|integer
 ---@return string
-function M.build_protocol_uri(tab, dir) return string.format("fyler://%s//%s", tostring(tab), dir) end
+function M.build_protocol_uri(dir) return string.format("fyler://%s", dir) end
 
 ---@param uri string|nil
 ---@return string
 function M.normalize_uri(uri)
-  local dir, tab = nil, nil
+  local dir = nil
   if not uri or uri == "" then
     dir = vim.fn.getcwd()
-    tab = tostring(vim.api.nvim_get_current_tabpage())
   elseif M.is_protocol_uri(uri) then
-    tab, dir = M.parse_protocol_uri(uri)
+    dir = M.parse_protocol_uri(uri)
     dir = dir or vim.fn.getcwd()
-    tab = tab or tostring(vim.api.nvim_get_current_tabpage())
   else
     dir = uri
-    tab = tostring(vim.api.nvim_get_current_tabpage())
   end
-  return M.build_protocol_uri(tab, require("fyler.lib.path").new(dir):posix_path())
+  return M.build_protocol_uri(require("fyler.lib.path").new(dir):posix_path())
 end
 
 ---@param uri string
----@return string|nil, string|nil
+---@return string|nil
 function M.parse_protocol_uri(uri)
-  if M.is_protocol_uri(uri) then return string.match(uri, "^fyler://(%d+)//(.*)$") end
+  if M.is_protocol_uri(uri) then return string.match(uri, "^fyler://(.*)$") end
 end
 
 ---@param str string

--- a/lua/fyler/views/finder/init.lua
+++ b/lua/fyler/views/finder/init.lua
@@ -126,7 +126,7 @@ function Finder:open(kind)
         return self:dispatch_refresh({ force_update = true })
       end
 
-      return M.navigate( bufname, { filter = { self.win.bufname }, force_update = true })
+      return M.navigate(bufname, { force_update = true })
     end,
     right         = view_cfg.win.right,
     title         = string.format("%s", self:getcwd()),
@@ -147,7 +147,7 @@ function Finder:open(kind)
 end
 
 ---@return string
-function Finder:getrwd() return util.select_n(2, helper.parse_protocol_uri(self.uri)) end
+function Finder:getrwd() return helper.parse_protocol_uri(self.uri) end
 
 ---@return string
 function Finder:getcwd() return Path.new(assert(self.files, "files is required").root_path):os_path() end
@@ -279,20 +279,85 @@ function Finder:dispatch_mutation()
   end)
 end
 
-local instances = {}
+-- Single global finder instance
+local current_finder = nil
 
----@param uri string|nil
+-- Global CWD tracking for Fyler (initialized when finder is created)
+local global_cwd = nil
+
+---Get the global current working directory for Fyler
+---@return string
+function M.get_current_dir() 
+  return global_cwd or vim.fn.getcwd()
+end
+
+---Set the global current working directory for Fyler and navigate to it
+---@param path string
+function M.set_current_dir(path)
+  -- Normalize and validate the path
+  local normalized_path = Path.new(path):posix_path()
+  assert(Path.new(normalized_path):is_directory(), "Path must be a valid directory")
+  
+  -- If the path hasn't changed, no need to rebuild
+  if global_cwd == normalized_path then return end
+  
+  -- Update global CWD
+  global_cwd = normalized_path
+  
+  -- Get the finder instance
+  local finder = M.instance()
+  
+  -- Recreate the Files instance with the new root path
+  if finder and finder.files then
+    -- Stop and clean all watchers from the old files instance
+    if finder.watcher then
+      finder.watcher:disable(true) -- true = clean up paths
+    end
+    
+    -- Create new Files instance
+    finder.files = require("fyler.views.finder.files").new({
+      open = true,
+      name = Path.new(normalized_path):basename(),
+      path = normalized_path,
+      finder = finder,
+    })
+    
+    -- Update the finder's URI to match the new path
+    finder.uri = helper.build_protocol_uri(normalized_path)
+    
+    -- Update the window buffer name to match new URI
+    if finder.win and finder.win.bufnr and vim.api.nvim_buf_is_valid(finder.win.bufnr) then
+      vim.api.nvim_buf_set_name(finder.win.bufnr, finder.uri)
+    end
+    
+    -- Update the window title
+    if finder.win and finder.win:has_valid_winid() then
+      local new_title = string.format("%s", Path.new(normalized_path):os_path())
+      finder.win:update_title(new_title)
+    end
+  end
+  
+  -- Navigate to the new path with forced update
+  vim.schedule(function()
+    M.navigate(normalized_path, { force_update = true })
+  end)
+end
+
+---Get or create the single global finder instance
 ---@return Finder
-function M.instance(uri)
-  uri = assert(helper.normalize_uri(uri), "Faulty URI")
+function M.instance()
+  if current_finder then return current_finder end
 
-  local finder = instances[uri]
-  if finder then return finder end
+  -- Initialize global_cwd on first instance creation if not already set
+  if not global_cwd then
+    global_cwd = vim.fn.getcwd()
+  end
 
-  local _, path = helper.parse_protocol_uri(uri) --[[@as string]]
-  assert(Path.new(path):is_directory(), "Path is not a valid directory")
+  -- Use global_cwd as the initial path
+  local path = global_cwd
+  local uri = helper.build_protocol_uri(path)
 
-  finder = Finder.new(uri)
+  local finder = Finder.new(uri)
   finder.watcher = require("fyler.views.finder.watcher").new(finder)
   finder.files = require("fyler.views.finder.files").new({
     open = true,
@@ -301,35 +366,25 @@ function M.instance(uri)
     finder = finder,
   })
 
-  instances[uri] = finder
-  return instances[uri]
+  current_finder = finder
+  return current_finder
 end
 
----@param fn fun(uri: string)
-function M.each_finder(fn) util.tbl_each(instances, fn) end
-
----@param uri string|nil
 ---@param kind WinKind|nil
-function M.open(uri, kind) M.instance(uri):open(kind or config.values.views.finder.win.kind) end
-
-local function _select(opts, handler)
-  if opts.filter then
-    util.tbl_each(opts.filter, function(uri)
-      if helper.is_protocol_uri(uri) then handler(uri) end
-    end)
-  else
-    M.each_finder(handler)
-  end
+function M.open(kind) 
+  M.instance():open(kind or config.values.views.finder.win.kind) 
 end
 
-M.close = vim.schedule_wrap(function(opts)
-  _select(opts or {}, function(uri) M.instance(uri):close() end)
+M.close = vim.schedule_wrap(function()
+  local finder = M.instance()
+  if finder and finder:isopen() then
+    finder:close()
+  end
 end)
 
----@param uri string|nil
 ---@param kind WinKind|nil
-M.toggle = vim.schedule_wrap(function(uri, kind)
-  local finder = M.instance(uri)
+M.toggle = vim.schedule_wrap(function(kind)
+  local finder = M.instance()
   if finder:isopen(kind) then
     finder:close()
   else
@@ -337,8 +392,11 @@ M.toggle = vim.schedule_wrap(function(uri, kind)
   end
 end)
 
-M.focus = vim.schedule_wrap(function(opts)
-  _select(opts or {}, function(uri) M.instance(uri).win:focus() end)
+M.focus = vim.schedule_wrap(function()
+  local finder = M.instance()
+  if finder and finder.win then
+    finder.win:focus()
+  end
 end)
 
 -- TODO: Can futher optimize by determining whether `files:navgiate` did any change or not?
@@ -346,38 +404,36 @@ end)
 M.navigate = vim.schedule_wrap(function(path, opts)
   opts = opts or {}
 
-  local set_cursor = vim.schedule_wrap(function(finder, ref_id)
+  local finder = M.instance()
+  
+  if not finder:isopen() then return end
+
+  local set_cursor = vim.schedule_wrap(function(ref_id)
     if finder:isopen() and ref_id then
       vim.api.nvim_win_call(finder.win.winid, function() vim.fn.search(string.format("/%05d ", ref_id)) end)
     end
   end)
 
-  _select(opts, function(uri)
-    local finder = M.instance(uri)
-    if not finder:isopen() then return end
+  local update_table = async.wrap(function(...) finder.files:update(...) end)
+  local navigate_path = async.wrap(function(...) finder:navigate(...) end)
 
-    local update_table = async.wrap(function(...) finder.files:update(...) end)
+  async.void(function()
+    if opts.force_update then update_table() end
 
-    local navigate_path = async.wrap(function(...) finder:navigate(...) end)
+    local ref_id
+    if path then
+      local path = vim.fn.fnamemodify(Path.new(path):posix_path(), ":p")
+      ref_id = util.select_n(2, navigate_path(path))
 
-    async.void(function()
-      if opts.force_update then update_table() end
-
-      local ref_id
-      if path then
-        local path = vim.fn.fnamemodify(Path.new(path):posix_path(), ":p")
-        ref_id = util.select_n(2, navigate_path(path))
-
-        if not ref_id then
-          local link = manager.find_link_path_from_resolved(path)
-          if link then ref_id = util.select_n(2, navigate_path(link)) end
-        end
+      if not ref_id then
+        local link = manager.find_link_path_from_resolved(path)
+        if link then ref_id = util.select_n(2, navigate_path(link)) end
       end
+    end
 
-      opts.onrender = function() set_cursor(finder, ref_id) end
+    opts.onrender = function() set_cursor(ref_id) end
 
-      finder:dispatch_refresh(opts)
-    end)
+    finder:dispatch_refresh(opts)
   end)
 end)
 

--- a/lua/fyler/views/finder/ui.lua
+++ b/lua/fyler/views/finder/ui.lua
@@ -118,10 +118,10 @@ local columns = {
       for i, get_entry in ipairs(entries) do
         local entry_data = ctx.get_entry_data(i)
         if entry_data then
-          local hl = get_entry[2]
-          highlights[i] = hl or ((entry_data.type == "directory") and "FylerFSDirectoryName" or nil)
+          local name_hl = get_entry[3]
+          highlights[i] = name_hl or ((entry_data.type == "directory") and "FylerFSDirectoryName" or nil)
         end
-        table.insert(column, Text(nil, { virt_text = { get_entry } }))
+        table.insert(column, Text(nil, { virt_text = { { get_entry[1], get_entry[2] } } }))
       end
 
       _next({ column = column, highlights = highlights })


### PR DESCRIPTION
Previously, when using the "replace" kind, window-local options (such as 'relativenumber' or 'cursorline') set by the user could be overridden by Fyler and not restored after hiding the window. This change saves the original window options before overriding them and restores them when the Fyler window is hidden, ensuring user settings are respected.

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)
