### PR TITLE
feat(git): separate icon and name highlights for status

### DIFF
--- a/lua/fyler/lib/git.lua
+++ b/lua/fyler/lib/git.lua
@@ -43,6 +43,17 @@ local hl_map = {
   Ignored = "FylerGitIgnored",
 }
 
+local icon_hl_map = {
+  Untracked = "FylerGitIconUntracked",
+  Added = "FylerGitIconAdded",
+  Modified = "FylerGitIconModified",
+  Deleted = "FylerGitIconDeleted",
+  Renamed = "FylerGitIconRenamed",
+  Copied = "FylerGitIconCopied",
+  Conflict = "FylerGitIconConflict",
+  Ignored = "FylerGitIconIgnored",
+}
+
 function M.map_entries_async(root_dir, entries, _next)
   M.build_modified_lookup_for_async(root_dir, function(modified_lookup)
     M.build_ignored_lookup_for_async(root_dir, entries, function(ignored_lookup)
@@ -50,9 +61,11 @@ function M.map_entries_async(root_dir, entries, _next)
       local result = util.tbl_map(
         entries,
         function(e)
+          local status = status_map[e]
           return {
-            config.values.views.finder.columns.git.symbols[icon_map[status_map[e]]] or "",
-            hl_map[icon_map[status_map[e]]],
+            config.values.views.finder.columns.git.symbols[icon_map[status]] or "",
+            icon_hl_map[icon_map[status]],
+            hl_map[icon_map[status]],
           }
         end
       )

--- a/lua/fyler/lib/hl.lua
+++ b/lua/fyler/lib/hl.lua
@@ -82,6 +82,7 @@ function M.setup()
 
     FylerGitAdded        = { fg = palette.green },
     FylerGitConflict     = { fg = palette.red },
+    FylerGitCopied       = { fg = palette.yellow },
     FylerGitDeleted      = { fg = palette.red },
     FylerGitIgnored      = { fg = palette.grey },
     FylerGitModified     = { fg = palette.yellow },
@@ -89,6 +90,17 @@ function M.setup()
     FylerGitStaged       = { fg = palette.green },
     FylerGitUnstaged     = { fg = palette.orange },
     FylerGitUntracked    = { fg = palette.cyan },
+
+    FylerGitIconAdded     = { link = "FylerGitAdded" },
+    FylerGitIconConflict  = { link = "FylerGitConflict" },
+    FylerGitIconCopied    = { link = "FylerGitCopied" },
+    FylerGitIconDeleted   = { link = "FylerGitDeleted" },
+    FylerGitIconIgnored   = { link = "FylerGitIgnored" },
+    FylerGitIconModified  = { link = "FylerGitModified" },
+    FylerGitIconRenamed   = { link = "FylerGitRenamed" },
+    FylerGitIconStaged    = { link = "FylerGitStaged" },
+    FylerGitIconUnstaged  = { link = "FylerGitUnstaged" },
+    FylerGitIconUntracked = { link = "FylerGitUntracked" },
 
     FylerWinPick         = { fg = palette.white, bg = palette.blue },
 

--- a/lua/fyler/views/finder/ui.lua
+++ b/lua/fyler/views/finder/ui.lua
@@ -118,10 +118,10 @@ local columns = {
       for i, get_entry in ipairs(entries) do
         local entry_data = ctx.get_entry_data(i)
         if entry_data then
-          local hl = get_entry[2]
-          highlights[i] = hl or ((entry_data.type == "directory") and "FylerFSDirectoryName" or nil)
+          local name_hl = get_entry[3]
+          highlights[i] = name_hl or ((entry_data.type == "directory") and "FylerFSDirectoryName" or nil)
         end
-        table.insert(column, Text(nil, { virt_text = { get_entry } }))
+        table.insert(column, Text(nil, { virt_text = { { get_entry[1], get_entry[2] } } }))
       end
 
       _next({ column = column, highlights = highlights })


### PR DESCRIPTION
This update introduces distinct highlight groups for git status icons and file names in the finder UI. It adds new icon-specific highlight groups and updates the mapping logic to use them, improving visual clarity and customization for git status indicators.

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)
