### PR TITLE
feat(icon): simplify devicon lookup by filename only

### DIFF
--- a/lua/fyler/integrations/icon/nvim_web_devicons.lua
+++ b/lua/fyler/integrations/icon/nvim_web_devicons.lua
@@ -5,7 +5,7 @@ function M.get(type, path)
   local ok, devicons = pcall(require, "nvim-web-devicons")
   assert(ok, "nvim-web-devicons are not installed or not loaded")
 
-  local icon, hl = devicons.get_icon(vim.fn.fnamemodify(path, ":t"), vim.fn.fnamemodify(path, ":e"))
+  local icon, hl = devicons.get_icon(vim.fn.fnamemodify(path, ":t"))
   icon = (type == "directory" and "" or (icon or ""))
   hl = hl or (type == "directory" and "Fylerblue" or "")
 


### PR DESCRIPTION
Refactored the icon retrieval logic to use only the filename for nvim-web-devicons lookup, removing the explicit extension argument. This improves compatibility with how icons are typically resolved and ensures directories and files are handled consistently.

The idea is to render the proper icons for final filename extensions like *.spec.ts

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)
