### PR TITLE
fix: normalize unsupported filesystem types in mini.icons integration.

### DIFF
--- a/lua/fyler/integrations/icon/mini_icons.lua
+++ b/lua/fyler/integrations/icon/mini_icons.lua
@@ -5,7 +5,18 @@ function M.get(type, name)
   local ok, miniicons = pcall(require, "mini.icons")
   assert(ok, "mini.icons are not installed or not loaded")
 
-  return miniicons.get(type, name)
+  local supported = {
+    default = true,
+    directory = true,
+    extension = true,
+    file = true,
+    filetype = true,
+    lsp = true,
+    os = true,
+  }
+
+  local category = supported[type] and type or "file"
+  return miniicons.get(category, name)
 end
 
 return M

--- a/tests/unit/test_mini_icon.lua
+++ b/tests/unit/test_mini_icon.lua
@@ -1,0 +1,55 @@
+local helper = require("tests.helper")
+local mini_icons = require("fyler.integrations.icon.mini_icons")
+
+local equal = helper.equal
+
+local T = helper.new_set()
+
+local function with_stubbed_mini_icons(fn)
+  local original = package.loaded["mini.icons"]
+  package.loaded["mini.icons"] = {
+    get = function(category, name) return category, name end,
+  }
+
+  local ok, err = pcall(fn)
+  package.loaded["mini.icons"] = original
+  assert(ok, err)
+end
+
+T["Supported Types"] = helper.new_set({
+  parametrize = {
+    { "default" },
+    { "directory" },
+    { "extension" },
+    { "file" },
+    { "filetype" },
+    { "lsp" },
+    { "os" },
+  },
+})
+
+T["Supported Types"]["Pass Through Category"] = function(category)
+  with_stubbed_mini_icons(function()
+    local actual_category, actual_name = mini_icons.get(category, "test_default")
+    equal(actual_category, category)
+    equal(actual_name, "test_default")
+  end)
+end
+
+T["Unsupported Types"] = helper.new_set({
+  parametrize = {
+    { "socket" },
+    { "block" },
+    { "char" },
+  },
+})
+
+T["Unsupported Types"]["Fallback To File"] = function(category)
+  with_stubbed_mini_icons(function()
+    local actual_category, actual_name = mini_icons.get(category, "test_default")
+    equal(actual_category, "file")
+    equal(actual_name, "test_default")
+  end)
+end
+
+return T


### PR DESCRIPTION
## Purpose of this Pull Request

When the icon is set to mini.icons and a directory containing files with unsupported types is opened, the error `vim.schedule callback: (mini.icons) "socket" is not a supported category.` occurs.

I have added a fix to prevent this error from occurring.

## Changes

I have added a fallback process that converts the file type to `file` when a file with a type not supported by mini.icons is encountered.