### PR TITLE
fix: redundant space after icon

### DIFF
--- a/lua/fyler/views/finder/ui.lua
+++ b/lua/fyler/views/finder/ui.lua
@@ -318,11 +318,11 @@ M.files = Component.new_async(function(node, onupdate)
     local icon, hl = icon_and_hl(item)
     local icon_highlight = (item.type == "directory") and "FylerFSDirectoryIcon" or hl
     local name_highlight = (item.type == "directory") and "FylerFSDirectoryName" or nil
-    icon = icon and (icon .. "  ") or ""
+    icon = icon and (icon .. " ") or ""
 
     local indentation_text = Text(string.rep(" ", 2 * depth))
     local icon_text = Text(icon, { highlight = icon_highlight })
-    local ref_id_text = item.ref_id and Text(string.format("/%05d ", item.ref_id)) or Text("")
+    local ref_id_text = item.ref_id and Text(string.format(" /%05d ", item.ref_id)) or Text("")
     local name_text = Text(item.name, { highlight = name_highlight })
     table.insert(files_column, Row({ indentation_text, icon_text, ref_id_text, name_text }))
   end

--- a/syntax/fyler.lua
+++ b/syntax/fyler.lua
@@ -3,7 +3,7 @@ vim.cmd([[
     finish
   endif
 
-  syn match FylerReferenceId /\/\d* / conceal
+  syn match FylerReferenceId / \/\d* / conceal
 
   let b:current_syntax = "Fyler"
 ]])


### PR DESCRIPTION
- [x] I have read and follow [CONTRIBUTING.md](https://github.com/A7Lavinraj/fyler.nvim/blob/main/CONTRIBUTING.md)

Removed one space between icon and filename. Usually 1 space, but there were 2.
I kept a leading space in concealed text.