### PR TITLE
refactor: indent guide ui

### DIFF
--- a/ftplugin/fyler_finder.lua
+++ b/ftplugin/fyler_finder.lua
@@ -1,34 +1,33 @@
 local finder = Fyler.import('fyler.finder')
 local ns = vim.api.nvim_create_namespace('FylerIndentGuide')
 
----@param indents table<integer, integer> --table of all indent levels for each line
----@param blanks table<integer, boolean> --table storing whether line is blank
----@param from integer --line to start scan from
----@param bottom integer --bottom of scan range
----@param max_indent integer --if next line has indent level greater than max_indent, then return nil as this is the final line in this level
+---@param indents table<integer, integer> table of all indent levels for each line
+---@param blanks table<integer, boolean> table storing whether line is blank
+---@param from integer line to start scan from
+---@param bottom integer bottom of scan range
+---@param max_indent integer if next line has indent level greater than max_indent, then return nil as this is the final line in this level
 ---@return integer|nil
 local function next_sibling_indent(indents, blanks, from, bottom, max_indent)
   for j = from + 1, bottom do
-    local next_indent = indents[j]
-    if next_indent ~= nil and not blanks[j] and next_indent <= max_indent then return next_indent end
+    if indents[j] == nil then return nil end
+    if not blanks[j] and indents[j] <= max_indent then return indents[j] end
   end
   return nil
 end
 
 ---check if the line has siblings at the same indent level below it
----@param indents table<integer, integer> --table of all indent levels for each line
----@param blanks table<integer, boolean> --table storing whether line is blank
----@param from integer --line to start scan from
----@param bottom integer --bottom of scan range
----@param level integer --indent level to check for siblings
----@return boolean --true if more siblings (same indent level) below
+---@param indents table<integer, integer> table of all indent levels for each line
+---@param blanks table<integer, boolean> table storing whether line is blank
+---@param from integer line to start scan from
+---@param bottom integer bottom of scan range
+---@param level integer indent level to check for siblings
+---@return boolean `true` if more siblings (same indent level) below
 local function has_sibling_below(indents, blanks, from, bottom, level)
   for j = from + 1, bottom do
-    local next_indent = indents[j]
-    if next_indent == nil then return false end
+    if indents[j] == nil then return false end
     if not blanks[j] then
-      if next_indent < level then return false end
-      if next_indent == level then return true end
+      if indents[j] < level then return false end
+      if indents[j] == level then return true end
     end
   end
   return false
@@ -36,12 +35,9 @@ end
 
 vim.api.nvim_set_decoration_provider(ns, {
   on_win = function(_, _, bufnr, toprow, botrow)
-    if vim.bo[bufnr].filetype ~= 'fyler_finder' then return end
-
     local inst = finder.instance_get_or_nil(vim.api.nvim_get_current_tabpage())
     if not (inst and inst.cache.ui.indent_guides and vim.bo[bufnr].filetype == 'fyler_finder') then return end
 
-    -- Normalize to 1-indexed
     if toprow == 0 then
       toprow = toprow + 1
       botrow = botrow + 1
@@ -50,17 +46,14 @@ vim.api.nvim_set_decoration_provider(ns, {
     local sw = vim.bo[bufnr].shiftwidth
     if sw == 0 then sw = vim.bo[bufnr].tabstop end
 
+    vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
     vim.api.nvim_buf_call(bufnr, function()
-      -- calculate indents and blank lines
       local indents, blanks = {}, {}
+
       for l = toprow, botrow do
         indents[l] = vim.fn.indent(l)
-        if vim.fn.getline(l):find('^%s*$') then blanks[l] = true end
-      end
-
-      -- resolve blank lines first so lines above can detect them as siblings
-      for l = toprow, botrow do
-        if blanks[l] then
+        if vim.fn.getline(l):find('^%s*$') then
+          blanks[l] = true
           local prev = vim.fn.prevnonblank(l)
           if prev > 0 then
             indents[l] = indents[prev] or vim.fn.indent(prev)
@@ -69,7 +62,6 @@ vim.api.nvim_set_decoration_provider(ns, {
         end
       end
 
-      -- render indent guides
       for l = toprow, botrow do
         local indent = indents[l]
         if indent > 0 then
@@ -80,12 +72,10 @@ vim.api.nvim_set_decoration_provider(ns, {
             local ilevel = lvl * sw
 
             if lvl < depth then
-              -- show bar if a sibling exists at this depth
               parts[#parts + 1] = has_sibling_below(indents, blanks, l, botrow, ilevel) and '│ ' or '  '
             else
-              -- last child or middle child
-              local next_indent = next_sibling_indent(indents, blanks, l, botrow, indent)
-              parts[#parts + 1] = (not next_indent or next_indent ~= indent) and '└╴' or '├╴'
+              local ni = next_sibling_indent(indents, blanks, l, botrow, indent)
+              parts[#parts + 1] = (not ni or ni ~= indent) and '└╴' or '├╴'
             end
           end
 
@@ -93,7 +83,6 @@ vim.api.nvim_set_decoration_provider(ns, {
             virt_text = { { table.concat(parts), 'FylerIndentGuide' } },
             virt_text_pos = 'overlay',
             hl_mode = 'combine',
-            ephemeral = true,
           })
         end
       end

--- a/ftplugin/fyler_finder.lua
+++ b/ftplugin/fyler_finder.lua
@@ -1,55 +1,102 @@
 local finder = Fyler.import('fyler.finder')
+local ns = vim.api.nvim_create_namespace('FylerIndentGuide')
 
-local indent_guide_ns = vim.api.nvim_create_namespace('FylerIndentGuide')
-local guide_cache = {}
+---@param indents table<integer, integer> --table of all indent levels for each line
+---@param blanks table<integer, boolean> --table storing whether line is blank
+---@param from integer --line to start scan from
+---@param bottom integer --bottom of scan range
+---@param max_indent integer --if next line has indent level greater than max_indent, then return nil as this is the final line in this level
+---@return integer|nil
+local function next_sibling_indent(indents, blanks, from, bottom, max_indent)
+  for j = from + 1, bottom do
+    local next_indent = indents[j]
+    if next_indent ~= nil and not blanks[j] and next_indent <= max_indent then return next_indent end
+  end
+  return nil
+end
 
-vim.api.nvim_set_decoration_provider(indent_guide_ns, {
-  on_win = function(_, _, buf_id)
-    local instance = finder.instance_get_or_nil(vim.api.nvim_get_current_tabpage())
-    if not (instance and instance.cache.ui.indent_guides and vim.bo[buf_id].filetype == 'fyler_finder') then return end
-    local tick = vim.b[buf_id].changedtick
-    if guide_cache[buf_id] and guide_cache[buf_id].tick == tick then return end
-    local lines = vim.api.nvim_buf_get_lines(buf_id, 0, -1, false)
-    local levels = {}
-    for i, line in ipairs(lines) do
-      levels[i - 1] = #line:match('^( *)')
+---check if the line has siblings at the same indent level below it
+---@param indents table<integer, integer> --table of all indent levels for each line
+---@param blanks table<integer, boolean> --table storing whether line is blank
+---@param from integer --line to start scan from
+---@param bottom integer --bottom of scan range
+---@param level integer --indent level to check for siblings
+---@return boolean --true if more siblings (same indent level) below
+local function has_sibling_below(indents, blanks, from, bottom, level)
+  for j = from + 1, bottom do
+    local next_indent = indents[j]
+    if next_indent == nil then return false end
+    if not blanks[j] then
+      if next_indent < level then return false end
+      if next_indent == level then return true end
     end
-    guide_cache[buf_id] = { tick = tick, levels = levels }
-  end,
+  end
+  return false
+end
 
-  on_line = function(_, _, buf_id, row)
-    local instance = finder.instance_get_or_nil(vim.api.nvim_get_current_tabpage())
-    if not (instance and instance.cache.ui.indent_guides and vim.bo[buf_id].filetype == 'fyler_finder') then return end
-    local cache = guide_cache[buf_id]
-    if not cache then return end
-    local s = cache.levels[row]
-    if not s or s == 0 then return end
-    for col = 0, s - 2, 2 do
-      local has_next = false
-      for j = row + 1, #cache.levels do
-        local next_s = cache.levels[j]
-        if next_s <= col then break end
-        if next_s >= col + 2 then
-          has_next = true
-          break
+vim.api.nvim_set_decoration_provider(ns, {
+  on_win = function(_, _, bufnr, toprow, botrow)
+    if vim.bo[bufnr].filetype ~= 'fyler_finder' then return end
+
+    local inst = finder.instance_get_or_nil(vim.api.nvim_get_current_tabpage())
+    if not (inst and inst.cache.ui.indent_guides and vim.bo[bufnr].filetype == 'fyler_finder') then return end
+
+    -- Normalize to 1-indexed
+    if toprow == 0 then
+      toprow = toprow + 1
+      botrow = botrow + 1
+    end
+
+    local sw = vim.bo[bufnr].shiftwidth
+    if sw == 0 then sw = vim.bo[bufnr].tabstop end
+
+    vim.api.nvim_buf_call(bufnr, function()
+      -- calculate indents and blank lines
+      local indents, blanks = {}, {}
+      for l = toprow, botrow do
+        indents[l] = vim.fn.indent(l)
+        if vim.fn.getline(l):find('^%s*$') then blanks[l] = true end
+      end
+
+      -- resolve blank lines first so lines above can detect them as siblings
+      for l = toprow, botrow do
+        if blanks[l] then
+          local prev = vim.fn.prevnonblank(l)
+          if prev > 0 then
+            indents[l] = indents[prev] or vim.fn.indent(prev)
+            blanks[l] = nil
+          end
         end
       end
-      local marker = has_next and '│ ' or '└ '
-      vim.api.nvim_buf_set_extmark(
-        buf_id,
-        indent_guide_ns,
-        row,
-        col,
-        { virt_text = { { marker, 'FylerIndentGuide' } }, virt_text_pos = 'overlay', ephemeral = true }
-      )
-    end
-  end,
-})
 
-vim.api.nvim_create_autocmd('BufDelete', {
-  buffer = vim.api.nvim_get_current_buf(),
-  callback = function(ev)
-    guide_cache[ev.buf] = nil
-    return true
+      -- render indent guides
+      for l = toprow, botrow do
+        local indent = indents[l]
+        if indent > 0 then
+          local depth = indent / sw
+          local parts = {}
+
+          for lvl = 1, depth do
+            local ilevel = lvl * sw
+
+            if lvl < depth then
+              -- show bar if a sibling exists at this depth
+              parts[#parts + 1] = has_sibling_below(indents, blanks, l, botrow, ilevel) and '│ ' or '  '
+            else
+              -- last child or middle child
+              local next_indent = next_sibling_indent(indents, blanks, l, botrow, indent)
+              parts[#parts + 1] = (not next_indent or next_indent ~= indent) and '└╴' or '├╴'
+            end
+          end
+
+          vim.api.nvim_buf_set_extmark(bufnr, ns, l - 1, 0, {
+            virt_text = { { table.concat(parts), 'FylerIndentGuide' } },
+            virt_text_pos = 'overlay',
+            hl_mode = 'combine',
+            ephemeral = true,
+          })
+        end
+      end
+    end)
   end,
 })


### PR DESCRIPTION
- remove `on_line` callback and handle everything in `on_win` (`on_line` is not recommended per nvim docs)
- redesign to match snacks explorer (added T-shaped markers)
- old design would show repeated extmarks when changing the indent level of a line, new design handles this gracefully (rerenders properly on each indent change
- remove caching for simplicity (no noticeable performance hit)

<img width="487" height="1395" alt="Screenshot 2026-06-18 005417" src="https://github.com/user-attachments/assets/43d82bbe-1c30-4ed7-8f61-acf197088b62" />
