### PR TITLE
fix: Allow to overrule default highlights

### DIFF
--- a/lua/fyler.lua
+++ b/lua/fyler.lua
@@ -182,6 +182,7 @@ H.setup_highlights = function()
   if hooks.on_highlight then hooks.on_highlight(highlights, palette) end
 
   for name, value in pairs(highlights) do
+    value.default = true
     vim.api.nvim_set_hl(0, name, value)
   end
 

--- a/lua/fyler/extensions/git.lua
+++ b/lua/fyler/extensions/git.lua
@@ -197,6 +197,7 @@ extensions.register({
     end,
     highlights_post = function()
       for name, hl in pairs(H.get_default_highlights()) do
+        hl.default = true
         vim.api.nvim_set_hl(0, name, hl)
       end
     end,


### PR DESCRIPTION
This change fixes an issue where the plugin would override highlight groups defined by the active colorscheme when it was loaded. It now only defines highlight groups that are not already defined, preserving colorscheme-provided and user-defined highlights.