### PR TITLE
fix: Make `action` optional in `fyler.Mapping`

### DIFF
--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -6,7 +6,7 @@ local M = {}
 ---@field on_rename fun(old_path: string, new_path: string)|nil
 
 ---@class fyler.Mapping
----@field action string|fun(self: fyler.Finder, args: table)
+---@field action string|fun(self: fyler.Finder, args: table)|nil
 ---@field args table|nil
 ---@field disabled boolean|nil
 ---@field opts table|nil


### PR DESCRIPTION
When commit da662594 was added, i notice that `action` is still required in the type annotation, making `action` field hinted as missing when using  `{ disabled = true }` in the config, even though it is still valid. so i think that convert action as optional might be a good options to do, 