### PR TITLE
[FIX] wrap hooks with `vim.schedule_wrap` to avoid fast event error 

### DIFF
--- a/lua/fyler/extensions/trash.lua
+++ b/lua/fyler/extensions/trash.lua
@@ -76,14 +76,14 @@ function H.process_serially(actions, idx, done)
         if err then vim.notify('Failed to write trash info: ' .. err, vim.log.levels.ERROR) end
         action.name = 'move'
         action.dst = target
-        hooks.on_delete(action.src)
+        vim.schedule_wrap(hooks.on_delete)(action.src)
         H.process_serially(actions, idx + 1, done)
       end)
     end)
   elseif H.platform == 'macos' then
     vim.system({ '/usr/bin/trash', action.src }, { text = true }, function(result)
       if result.code == 0 then
-        hooks.on_delete(action.src)
+        vim.schedule_wrap(hooks.on_delete)(action.src)
         H.process_serially(actions, idx + 1, done)
       else
         vim.notify('Trash failed: ' .. (result.stdout or result.stderr or 'unknown error'), vim.log.levels.ERROR)
@@ -96,7 +96,7 @@ function H.process_serially(actions, idx, done)
     )
     vim.system({ 'powershell', '-NoProfile', '-Command', cmd }, { text = true }, function(result)
       if result.code == 0 then
-        hooks.on_delete(action.src)
+        vim.schedule_wrap(hooks.on_delete)(action.src)
         H.process_serially(actions, idx + 1, done)
       else
         vim.notify('Trash failed: ' .. (result.stdout or result.stderr or 'unknown error'), vim.log.levels.ERROR)

--- a/lua/fyler/finder.lua
+++ b/lua/fyler/finder.lua
@@ -960,9 +960,9 @@ function Finder:mutate()
           local hooks = config.DATA.hooks
           for _, action in ipairs(ordered_actions) do
             if action.name == 'delete' then
-              hooks.on_delete(action.src)
+              vim.schedule_wrap(hooks.on_delete)(action.src)
             elseif action.name == 'move' then
-              hooks.on_rename(action.src, action.dst)
+              vim.schedule_wrap(hooks.on_rename)(action.src, action.dst)
             end
           end
         end)


### PR DESCRIPTION
fix #330 