### PR TITLE
[PATCH] Restore finder view in finder window, not focused window

### DIFF
--- a/lua/fyler/finder.lua
+++ b/lua/fyler/finder.lua
@@ -349,7 +349,9 @@ end
 ---@private
 H.finish_refresh = function(instance)
   if instance._view.lnum then
-    vim.fn.winrestview({ lnum = instance._view.lnum, col = 0 })
+    if util.window_is_valid(instance.win_id) then
+      vim.api.nvim_win_call(instance.win_id, function() vim.fn.winrestview({ lnum = instance._view.lnum, col = 0 }) end)
+    end
     instance._view = {}
   end
 

--- a/tests/integrations/finder.test.lua
+++ b/tests/integrations/finder.test.lua
@@ -368,4 +368,42 @@ T['Finder with kind']['can handle chain-dependencies in file system manipulation
   helper.expect.equality(vim.fn.readfile(helper.joinpath(tmpdir, 'd-file')), { 'ROOT/c-file' })
 end
 
+T['follow_current_file does not move cursor in unfocused windows'] = function()
+  local tmpdir = helper.get_tmpdir('data', { 'dir/', 'dir/a-file', 'dir/b-file', 'dir/c-file' })
+  n.fwd_lua('require("fyler").setup')({ follow_current_file = true })
+  n.fwd_lua('require("fyler").open')({ kind = 'split_left_most', root_path = tmpdir })
+  vim.uv.sleep(50)
+
+  local deep_file = helper.joinpath(tmpdir, 'dir', 'c-file')
+
+  -- Open a non-finder window holding a 10-line buffer, park the cursor on line 1,
+  -- focus it, then queue a follow() targeting a deep tree entry. The follow refresh
+  -- restores the saved view on a later tick (vim.schedule); by then this non-finder
+  -- window is focused. The restore must target the finder window, never this one.
+  n.lua(
+    [[
+    local finder = require('fyler.finder')
+    local instance = assert(finder.instance_get_or_nil(), 'finder instance missing')
+
+    vim.cmd('botright vsplit')
+    local win = vim.api.nvim_get_current_win()
+    local buf = vim.api.nvim_create_buf(false, true)
+    local lines = {}
+    for i = 1, 10 do lines[i] = 'line ' .. i end
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    vim.api.nvim_win_set_buf(win, buf)
+    vim.api.nvim_win_set_cursor(win, { 1, 0 })
+    vim.api.nvim_set_current_win(win)
+
+    _G.obs_win = win
+    instance:follow({ target_path = ..., force = true })
+  ]],
+    { deep_file }
+  )
+
+  vim.uv.sleep(50)
+
+  helper.expect.equality(n.lua_get('vim.api.nvim_win_get_cursor(_G.obs_win)[1]'), 1)
+end
+
 return T


### PR DESCRIPTION
Fixes #336.

## Problem

With `follow_current_file = true` and the finder open, changing focus between unrelated windows can move the cursor in the window that gains focus. The cursor jumps to the line corresponding to the followed file's position in the tree.

`H.finish_refresh` restored the saved view with a bare `vim.fn.winrestview`, which acts on whatever window is currently focused. The restore runs inside a `vim.schedule_wrap` callback, so by the time it fires focus may already be in another window, and `winrestview` moves that window's cursor.

This is a regression from 41cde5b. Before that commit the restore was wrapped in `nvim_win_call(self.win_id, ...)`, which forced the operation to run with the finder window as current. The selective-refresh rewrite centralized view restoration into `H.finish_refresh` but dropped that wrapper.

## Fix

Wrap the restore in `nvim_win_call(instance.win_id, ...)` with a validity guard, so it always targets the finder window regardless of actual focus.

```lua
H.finish_refresh = function(instance)
  if instance._view.lnum then
    if util.window_is_valid(instance.win_id) then
      vim.api.nvim_win_call(instance.win_id, function() vim.fn.winrestview({ lnum = instance._view.lnum, col = 0 }) end)
    end
    instance._view = {}
  end
  ...
```

## Test

Adds a regression test in `tests/integrations/finder.test.lua` that opens the finder with `follow_current_file = true`, focuses a separate non-finder window with a multi-line buffer and the cursor on line 1, then queues a `follow()` whose scheduled view restore fires while that non-finder window is focused. The test asserts the cursor stays put. It was confirmed to fail before the fix (cursor jumped to the followed file's tree line) and pass after.

Full suite (317 cases) passes. `stylua` and `selene` are clean.