### PR TITLE
[PATCH] Add hidden items guard at `Finder:follow`

### DIFF
--- a/lua/fyler/finder.lua
+++ b/lua/fyler/finder.lua
@@ -671,6 +671,7 @@ function Finder:follow(args)
   local accumulated = root_path
   for _, segment in ipairs(libpath.do_split(relative)) do
     accumulated = libpath.do_join(accumulated, segment)
+    if libfs.is_hidden(accumulated, self.cache.ui.hidden_items) then break end
     self.state:toggle(accumulated, true)
   end
 


### PR DESCRIPTION
resolves: #345

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/FylerOrg/fyler.nvim/blob/main/CONTRIBUTING.md)
