### PR TITLE
fix: make UiConfig and HiddenItemsConfig fields optional to avoid missing-fields diagnostics

### DIFF
--- a/lua/fyler/config.lua
+++ b/lua/fyler/config.lua
@@ -13,14 +13,14 @@ local M = {}
 ---@field opts table|nil
 
 ---@class fyler.HiddenItemsConfig
----@field always_hidden string[]
----@field always_visible string[]
----@field patterns string[]
----@field switches string[]
+---@field always_hidden string[]|nil
+---@field always_visible string[]|nil
+---@field patterns string[]|nil
+---@field switches string[]|nil
 
 ---@class fyler.UiConfig
----@field hidden_items fyler.HiddenItemsConfig
----@field indent_guides boolean
+---@field hidden_items fyler.HiddenItemsConfig|nil
+---@field indent_guides boolean|nil
 
 ---@class fyler.WindowLayoutConfig
 ---@field border string|nil


### PR DESCRIPTION
All four fields in `fyler.HiddenItemsConfig` (`always_hidden`, `always_visible`, `patterns`, `switches`) and both fields in `fyler.UiConfig` (`hidden_items`, `indent_guides`) are annotated without `|nil`, so luals reports `missing-fields` when a user config only provides a subset.

```python
ui = {
  hidden_items = {
    switches = { "dotfiles" },
  },
  indent_guides = true,
},
```
<img width="1283" height="64" alt="image" src="https://github.com/user-attachments/assets/3b0e2e24-ed26-4163-bcf9-9c2ffd056a0d" />

At runtime works fine due to `vim.tbl_deep_extend` while seting config,  but the type annotations don't reflect that these fields are optional in user configs.

This PR adds `|nil` to all affected fields, matching the existing pattern in `HooksConfig` and `Mapping`