### PR TITLE
fix: don't open default explorer when in diff mode

### DIFF
--- a/lua/fyler.lua
+++ b/lua/fyler.lua
@@ -148,12 +148,20 @@ H.setup_autocmds = function()
 
     -- TODO: supports all schemes
     -- Hijack directory buffers similar to |netrw|.
-    au('BufEnter', '*', function()
+    au('BufEnter', '*', function(ev)
+      -- Open explorer only on intentional directory edit (not in a script)
+      if vim.api.nvim_get_current_buf() ~= ev.buf or vim.wo.diff then return end
+
       local buf_name = vim.api.nvim_buf_get_name(0)
       if vim.fn.isdirectory(buf_name) == 0 then return end
 
-      vim.api.nvim_buf_delete(0, { force = true })
-      vim.schedule_wrap(Fyler.open)({ root_path = buf_name })
+      -- Delay opening to not act if the buffer was opened temporarily in a script
+      vim.schedule(function()
+        if vim.api.nvim_get_current_buf() ~= ev.buf or vim.wo.diff then return end
+
+        vim.api.nvim_buf_delete(0, { force = true })
+        Fyler.open({ root_path = buf_name })
+      end)
     end, 'Track directory edit')
   end
 

--- a/tests/integrations/default_explorer.test.lua
+++ b/tests/integrations/default_explorer.test.lua
@@ -1,0 +1,42 @@
+local helper = require('tests.helper')
+local n = helper.new_child_neovim()
+local T = helper.new_set({ hooks = { pre_case = n.setup, post_once = n.stop } })
+
+local eq = helper.expect.equality
+
+local is_finder_active = function()
+  return n.lua_get([[(function()
+    for _, win in ipairs(vim.api.nvim_list_wins()) do
+      if vim.bo[vim.api.nvim_win_get_buf(win)].filetype == 'fyler_finder' then return true end
+    end
+    return false
+  end)()]])
+end
+
+T['Default explorer'] = helper.new_set()
+
+T['Default explorer']['is opened on directory edit'] = function()
+  local tmpdir = helper.get_tmpdir('data', { 'a-file' })
+  n.fwd_lua('require("fyler").setup')({})
+  n.cmd('edit ' .. tmpdir)
+  eq(is_finder_active(), true)
+end
+
+T['Default explorer']['is opened only for the current buffer'] = function()
+  local tmpdir = helper.get_tmpdir('data', { 'a-file' })
+  n.fwd_lua('require("fyler").setup')({})
+  n.lua(('vim.cmd("edit %s"); vim.cmd("enew")'):format(tmpdir))
+  eq(is_finder_active(), false)
+  n.cmd('bprev')
+  eq(is_finder_active(), true)
+end
+
+T['Default explorer']['is not opened during diff-mode'] = function()
+  local tmpdir = helper.get_tmpdir('data', { 'a-file' })
+  n.fwd_lua('require("fyler").setup')({})
+  n.wo.diff = true
+  n.cmd('edit ' .. tmpdir)
+  eq(is_finder_active(), false)
+end
+
+return T


### PR DESCRIPTION
This could happen by using the built-in directory diff tool (`:h difftool`)

Based on https://github.com/nvim-mini/mini.nvim/commit/5d4545a09114af9384d592e8beb06ec88bcf8ec1 and https://github.com/nvim-mini/mini.nvim/commit/9d264625772ae5f523dd06b717a47c201335790e

fixes: #358

- [x] I have read and follow [CONTRIBUTING.md](https://github.com/FylerOrg/fyler.nvim/blob/main/CONTRIBUTING.md)

BTW, you should update the PR template because there is no `CONTRIBUTING.md` anymore
